### PR TITLE
feat: add keyword_search tool for pinecone-rag-sparse index (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ npm run build
 npm test
 ```
 
-+### Testing the keyword_search tool
+### Testing the keyword_search tool
 
 1. **Connectivity and keyword search (script):**  
    Run the search test script (includes a keyword search step against the sparse index):

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ npm run build
 npm test
 ```
 
-### Testing the keyword_search tool
++### Testing the keyword_search tool
 
 1. **Connectivity and keyword search (script):**  
    Run the search test script (includes a keyword search step against the sparse index):

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ The server requires a Pinecone API key and supports the following configuration 
 | ---------------------------------- | -------- | ---------------------- | ------------------------------------------------ |
 | `PINECONE_API_KEY`                 | Yes      | -                      | Your Pinecone API key                            |
 | `PINECONE_INDEX_NAME`              | No       | `rag-hybrid`           | Pinecone index name (dense + sparse for hybrid)   |
-| `PINECONE_SPARSE_INDEX_NAME`       | No       | `pinecone-rag-sparse`  | Sparse index for `keyword_search` tool           |
 | `PINECONE_RERANK_MODEL`            | No       | `bge-reranker-v2-m3`   | Reranking model                                  |
 | `PINECONE_READ_ONLY_MCP_LOG_LEVEL` | No       | `INFO`                 | Logging level                                    |
 
@@ -146,7 +145,6 @@ node node_modules/@will-cppa/pinecone-read-only-mcp/dist/index.js --api-key YOUR
 ```
 --api-key TEXT           Pinecone API key (or set PINECONE_API_KEY env var)
 --index-name TEXT        Pinecone index name [default: rag-hybrid]
---sparse-index-name TEXT Sparse index for keyword_search [default: pinecone-rag-sparse]
 --rerank-model TEXT      Reranking model [default: bge-reranker-v2-m3]
 --log-level TEXT         Logging level [default: INFO]
 --help, -h               Show help message
@@ -342,7 +340,7 @@ Returns the **unique document count** matching a metadata filter and semantic qu
 
 ### `keyword_search`
 
-Performs **keyword (lexical/sparse-only)** search over the dedicated sparse index (default: `pinecone-rag-sparse`). Use for exact or keyword-style queries. Does not use the dense index or semantic reranking. Call `list_namespaces` first to discover namespaces; `suggest_query_params` is optional.
+Performs **keyword (lexical/sparse-only)** search over the dedicated sparse index (default: `rag-hybrid-sparse`, i.e. `{PINECONE_INDEX_NAME}-sparse`). Use for exact or keyword-style queries. Does not use the dense index or semantic reranking. Call `list_namespaces` first to discover namespaces; `suggest_query_params` is optional.
 
 **Parameters:**
 
@@ -363,7 +361,7 @@ Performs **keyword (lexical/sparse-only)** search over the dedicated sparse inde
   "status": "success",
   "query": "contracts C++",
   "namespace": "wg21-papers",
-  "index": "pinecone-rag-sparse",
+  "index": "rag-hybrid-sparse",
   "result_count": 5,
   "results": [
     {
@@ -518,7 +516,7 @@ npm test
    ```bash
    PINECONE_API_KEY=your-key npm run test:search
    ```
-   If the sparse index (`pinecone-rag-sparse` by default) does not exist or has no data, the keyword search step is skipped with a warning.
+   If the sparse index (`rag-hybrid-sparse` by default) does not exist or has no data, the keyword search step is skipped with a warning.
 
 2. **Via MCP client:**  
    Start the server and call the `keyword_search` tool with `query_text`, `namespace` (from `list_namespaces`), and optional `top_k` or `metadata_filter`. Response shape is the same as the `query` tool (e.g. `results` with ids, metadata, scores; `reranked` is always `false`).

--- a/scripts/test-search.ts
+++ b/scripts/test-search.ts
@@ -153,6 +153,8 @@ async function test() {
     }
 
     // Test 5: Keyword (sparse-only) search on pinecone-rag-sparse
+    let duration5: number | undefined;
+    let test5Skipped = false;
     console.log(`\n🔤 Test 5: Keyword search (sparse-only index)`);
     console.log(`   Namespace: "${testNamespace}"`);
     console.log(`   Query: "test query"`);
@@ -164,14 +166,21 @@ async function test() {
         namespace: testNamespace,
         topK: 3,
       });
-      const duration5 = Date.now() - startTime5;
+      duration5 = Date.now() - startTime5;
       console.log(`✅ Keyword search returned ${results5.length} result(s) in ${duration5}ms`);
       if (results5.length > 0) {
-        console.log(`   First result score: ${results5[0].score.toFixed(4)}, reranked: ${results5[0].reranked}`);
+        console.log(
+          `   First result score: ${results5[0].score.toFixed(4)}, reranked: ${results5[0].reranked}`
+        );
       }
     } catch (kwError) {
-      console.log(`⚠️  Keyword search skipped: ${kwError instanceof Error ? kwError.message : String(kwError)}`);
-      console.log(`   Ensure PINECONE_SPARSE_INDEX_NAME (e.g. pinecone-rag-sparse) exists and has data.`);
+      test5Skipped = true;
+      console.log(
+        `⚠️  Keyword search skipped: ${kwError instanceof Error ? kwError.message : String(kwError)}`
+      );
+      console.log(
+        `   Ensure PINECONE_SPARSE_INDEX_NAME (e.g. pinecone-rag-sparse) exists and has data.`
+      );
     }
 
     console.log('\n✨ All tests completed successfully!');
@@ -180,6 +189,11 @@ async function test() {
     console.log(`  With reranking:       ${duration2}ms`);
     if (duration3 !== undefined) {
       console.log(`  With metadata filter: ${duration3}ms`);
+    }
+    if (duration5 !== undefined) {
+      console.log(`  Keyword search:       ${duration5}ms`);
+    } else if (test5Skipped) {
+      console.log(`  Keyword search:       skipped`);
     }
     console.log(`  Reranking overhead:   ${duration2 - duration1}ms`);
   } catch (error) {

--- a/scripts/test-search.ts
+++ b/scripts/test-search.ts
@@ -152,6 +152,28 @@ async function test() {
       );
     }
 
+    // Test 5: Keyword (sparse-only) search on pinecone-rag-sparse
+    console.log(`\n🔤 Test 5: Keyword search (sparse-only index)`);
+    console.log(`   Namespace: "${testNamespace}"`);
+    console.log(`   Query: "test query"`);
+    console.log(`   Top K: 3`);
+    try {
+      const startTime5 = Date.now();
+      const results5 = await client.keywordSearch({
+        query: 'test query',
+        namespace: testNamespace,
+        topK: 3,
+      });
+      const duration5 = Date.now() - startTime5;
+      console.log(`✅ Keyword search returned ${results5.length} result(s) in ${duration5}ms`);
+      if (results5.length > 0) {
+        console.log(`   First result score: ${results5[0].score.toFixed(4)}, reranked: ${results5[0].reranked}`);
+      }
+    } catch (kwError) {
+      console.log(`⚠️  Keyword search skipped: ${kwError instanceof Error ? kwError.message : String(kwError)}`);
+      console.log(`   Ensure PINECONE_SPARSE_INDEX_NAME (e.g. pinecone-rag-sparse) exists and has data.`);
+    }
+
     console.log('\n✨ All tests completed successfully!');
     console.log(`\nPerformance comparison:`);
     console.log(`  Without reranking:    ${duration1}ms`);

--- a/scripts/test-search.ts
+++ b/scripts/test-search.ts
@@ -152,35 +152,48 @@ async function test() {
       );
     }
 
-    // Test 5: Keyword (sparse-only) search on pinecone-rag-sparse
+    // Test 5: Keyword (sparse-only) search — use namespace from sparse index, not dense
     let duration5: number | undefined;
     let test5Skipped = false;
-    console.log(`\n🔤 Test 5: Keyword search (sparse-only index)`);
-    console.log(`   Namespace: "${testNamespace}"`);
-    console.log(`   Query: "test query"`);
-    console.log(`   Top K: 3`);
-    try {
-      const startTime5 = Date.now();
-      const results5 = await client.keywordSearch({
-        query: 'test query',
-        namespace: testNamespace,
-        topK: 3,
-      });
-      duration5 = Date.now() - startTime5;
-      console.log(`✅ Keyword search returned ${results5.length} result(s) in ${duration5}ms`);
-      if (results5.length > 0) {
+    const sparseNamespaces = await client.listNamespacesFromKeywordIndex();
+    if (sparseNamespaces.length === 0) {
+      test5Skipped = true;
+      console.log(`\n🔤 Test 5: Keyword search (sparse-only index)`);
+      console.log(
+        `⚠️  Keyword search skipped: sparse index has no namespaces (or index unavailable).`
+      );
+      console.log(
+        `   Ensure PINECONE_SPARSE_INDEX_NAME (e.g. pinecone-rag-sparse or rag-hybrid-sparse) exists and has data.`
+      );
+    } else {
+      const sparseTestNamespace = sparseNamespaces[0].namespace;
+      console.log(`\n🔤 Test 5: Keyword search (sparse-only index)`);
+      console.log(`   Namespace: "${sparseTestNamespace}" (from sparse index)`);
+      console.log(`   Query: "test query"`);
+      console.log(`   Top K: 3`);
+      try {
+        const startTime5 = Date.now();
+        const results5 = await client.keywordSearch({
+          query: 'test query',
+          namespace: sparseTestNamespace,
+          topK: 3,
+        });
+        duration5 = Date.now() - startTime5;
+        console.log(`✅ Keyword search returned ${results5.length} result(s) in ${duration5}ms`);
+        if (results5.length > 0) {
+          console.log(
+            `   First result score: ${results5[0].score.toFixed(4)}, reranked: ${results5[0].reranked}`
+          );
+        }
+      } catch (kwError) {
+        test5Skipped = true;
         console.log(
-          `   First result score: ${results5[0].score.toFixed(4)}, reranked: ${results5[0].reranked}`
+          `⚠️  Keyword search skipped: ${kwError instanceof Error ? kwError.message : String(kwError)}`
+        );
+        console.log(
+          `   Ensure PINECONE_SPARSE_INDEX_NAME exists and namespace "${sparseTestNamespace}" has data.`
         );
       }
-    } catch (kwError) {
-      test5Skipped = true;
-      console.log(
-        `⚠️  Keyword search skipped: ${kwError instanceof Error ? kwError.message : String(kwError)}`
-      );
-      console.log(
-        `   Ensure PINECONE_SPARSE_INDEX_NAME (e.g. pinecone-rag-sparse) exists and has data.`
-      );
     }
 
     console.log('\n✨ All tests completed successfully!');

--- a/scripts/test-search.ts
+++ b/scripts/test-search.ts
@@ -163,7 +163,7 @@ async function test() {
         `⚠️  Keyword search skipped: sparse index has no namespaces (or index unavailable).`
       );
       console.log(
-        `   Ensure PINECONE_SPARSE_INDEX_NAME (e.g. pinecone-rag-sparse or rag-hybrid-sparse) exists and has data.`
+        `   Ensure the sparse index (e.g. rag-hybrid-sparse) exists and has data.`
       );
     } else {
       const sparseTestNamespace = sparseNamespaces[0].namespace;
@@ -191,7 +191,7 @@ async function test() {
           `⚠️  Keyword search skipped: ${kwError instanceof Error ? kwError.message : String(kwError)}`
         );
         console.log(
-          `   Ensure PINECONE_SPARSE_INDEX_NAME exists and namespace "${sparseTestNamespace}" has data.`
+          `   Ensure the sparse index exists and namespace "${sparseTestNamespace}" has data.`
         );
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,8 @@
  */
 
 export const DEFAULT_INDEX_NAME = 'rag-hybrid';
+/** Default index name for keyword (sparse-only) search. Used by the keyword_search tool. */
+export const DEFAULT_SPARSE_INDEX_NAME = 'pinecone-rag-sparse';
 export const DEFAULT_RERANK_MODEL = 'bge-reranker-v2-m3';
 export const DEFAULT_TOP_K = 10;
 export const MAX_TOP_K = 100;
@@ -45,6 +47,7 @@ Features:
 - Count: Use the count tool for "how many X?" questions; it uses semantic search only and minimal fields (no content) for performance, returning unique document count.
 - URL Generation: Use generate_urls to synthesize URLs for namespaces that support it when metadata lacks url.
 - Document reassembly: Use query_documents to get whole documents (chunks grouped and merged by document_number/doc_id/url) for content analysis or summarization.
+- Keyword search: Use keyword_search to query the sparse index (e.g. pinecone-rag-sparse) for lexical/keyword-only retrieval without reranking.
 
 Usage:
 1. Use list_namespaces (cached for 30 minutes) to discover available namespaces in the index

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,8 +3,6 @@
  */
 
 export const DEFAULT_INDEX_NAME = 'rag-hybrid';
-/** Default index name for keyword (sparse-only) search. Used by the keyword_search tool. */
-export const DEFAULT_SPARSE_INDEX_NAME = 'pinecone-rag-sparse';
 export const DEFAULT_RERANK_MODEL = 'bge-reranker-v2-m3';
 export const DEFAULT_TOP_K = 10;
 export const MAX_TOP_K = 100;
@@ -47,7 +45,7 @@ Features:
 - Count: Use the count tool for "how many X?" questions; it uses semantic search only and minimal fields (no content) for performance, returning unique document count.
 - URL Generation: Use generate_urls to synthesize URLs for namespaces that support it when metadata lacks url.
 - Document reassembly: Use query_documents to get whole documents (chunks grouped and merged by document_number/doc_id/url) for content analysis or summarization.
-- Keyword search: Use keyword_search to query the sparse index (e.g. pinecone-rag-sparse) for lexical/keyword-only retrieval without reranking.
+- Keyword search: Use keyword_search to query the sparse index (default: rag-hybrid-sparse) for lexical/keyword-only retrieval without reranking.
 
 Usage:
 1. Use list_namespaces (cached for 30 minutes) to discover available namespaces in the index

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { PineconeClient } from './pinecone-client.js';
 import { setupServer, setPineconeClient } from './server.js';
-import { DEFAULT_INDEX_NAME, DEFAULT_RERANK_MODEL, DEFAULT_SPARSE_INDEX_NAME } from './constants.js';
+import {
+  DEFAULT_INDEX_NAME,
+  DEFAULT_RERANK_MODEL,
+  DEFAULT_SPARSE_INDEX_NAME,
+} from './constants.js';
 import type { LogLevel } from './config.js';
 import { setLogLevel } from './logger.js';
 import * as dotenv from 'dotenv';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,7 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { PineconeClient } from './pinecone-client.js';
 import { setupServer, setPineconeClient } from './server.js';
-import {
-  DEFAULT_INDEX_NAME,
-  DEFAULT_RERANK_MODEL,
-  DEFAULT_SPARSE_INDEX_NAME,
-} from './constants.js';
+import { DEFAULT_INDEX_NAME, DEFAULT_RERANK_MODEL } from './constants.js';
 import type { LogLevel } from './config.js';
 import { setLogLevel } from './logger.js';
 import * as dotenv from 'dotenv';
@@ -26,7 +22,6 @@ dotenv.config();
 interface CLIOptions {
   apiKey?: string;
   indexName?: string;
-  sparseIndexName?: string;
   rerankModel?: string;
   logLevel?: string;
 }
@@ -47,10 +42,6 @@ function parseArgs(): CLIOptions {
         break;
       case '--index-name':
         options.indexName = nextArg;
-        i++;
-        break;
-      case '--sparse-index-name':
-        options.sparseIndexName = nextArg;
         i++;
         break;
       case '--rerank-model':
@@ -81,16 +72,14 @@ Usage: pinecone-read-only-mcp [options]
 
 Options:
   --api-key TEXT           Pinecone API key (or set PINECONE_API_KEY env var)
-  --index-name TEXT        Pinecone index name [default: ${DEFAULT_INDEX_NAME}]
-  --sparse-index-name TEXT Sparse index for keyword_search [default: ${DEFAULT_SPARSE_INDEX_NAME}]
+  --index-name TEXT        Pinecone index name [default: ${DEFAULT_INDEX_NAME}]; sparse index is {index-name}-sparse
   --rerank-model TEXT      Reranking model [default: ${DEFAULT_RERANK_MODEL}]
   --log-level TEXT         Logging level [default: INFO]
   --help, -h               Show this help message
 
 Environment Variables:
   PINECONE_API_KEY              Pinecone API key
-  PINECONE_INDEX_NAME           Pinecone index name
-  PINECONE_SPARSE_INDEX_NAME    Sparse index for keyword_search tool
+  PINECONE_INDEX_NAME           Pinecone index name (sparse index: {name}-sparse)
   PINECONE_RERANK_MODEL         Reranking model name
   PINECONE_READ_ONLY_MCP_LOG_LEVEL  Logging level
 
@@ -130,10 +119,6 @@ async function main(): Promise<void> {
 
     // Get configuration
     const indexName = options.indexName || process.env['PINECONE_INDEX_NAME'] || DEFAULT_INDEX_NAME;
-    const sparseIndexName =
-      options.sparseIndexName ||
-      process.env['PINECONE_SPARSE_INDEX_NAME'] ||
-      DEFAULT_SPARSE_INDEX_NAME;
     const rerankModel =
       options.rerankModel || process.env['PINECONE_RERANK_MODEL'] || DEFAULT_RERANK_MODEL;
 
@@ -141,13 +126,12 @@ async function main(): Promise<void> {
     const client = new PineconeClient({
       apiKey,
       indexName,
-      sparseIndexName,
       rerankModel,
     });
     setPineconeClient(client);
 
     console.error(`Starting Pinecone Read-Only MCP server with stdio transport`);
-    console.error(`Using Pinecone index: ${indexName} (keyword search: ${sparseIndexName})`);
+    console.error(`Using Pinecone index: ${indexName} (sparse: ${indexName}-sparse)`);
     console.error(`Log level: ${logLevel}`);
 
     // Setup server

--- a/src/pinecone-client.ts
+++ b/src/pinecone-client.ts
@@ -158,6 +158,29 @@ export class PineconeClient {
   }
 
   /**
+   * List namespaces present on the keyword (sparse) index used for keyword_search.
+   * Use this to choose a namespace for sparse-only queries instead of the dense index list.
+   */
+  async listNamespacesFromKeywordIndex(): Promise<
+    Array<{ namespace: string; recordCount: number }>
+  > {
+    try {
+      const keywordIndex = await this.ensureKeywordIndex();
+      const stats = keywordIndex.describeIndexStats
+        ? await keywordIndex.describeIndexStats()
+        : undefined;
+      const namespaces = stats?.namespaces ?? {};
+      return Object.entries(namespaces).map(([namespace, info]) => ({
+        namespace,
+        recordCount: info?.recordCount ?? 0,
+      }));
+    } catch (error) {
+      logError('Error listing namespaces from keyword index', error);
+      return [];
+    }
+  }
+
+  /**
    * List all available namespaces with their metadata information
    *
    * Fetches namespaces from the index stats and samples records to discover

--- a/src/pinecone-client.ts
+++ b/src/pinecone-client.ts
@@ -20,6 +20,7 @@ import type {
   QueryParams,
   CountParams,
   CountResult,
+  KeywordSearchParams,
   MergedHit,
   NamespaceHandle,
   SearchableIndex,
@@ -28,6 +29,7 @@ import type {
 import {
   DEFAULT_INDEX_NAME,
   DEFAULT_RERANK_MODEL,
+  DEFAULT_SPARSE_INDEX_NAME,
   DEFAULT_TOP_K,
   MAX_TOP_K,
   COUNT_TOP_K,
@@ -55,6 +57,7 @@ function inferMetadataFieldType(value: unknown): string {
 export class PineconeClient {
   private apiKey: string;
   private indexName: string;
+  private sparseIndexName: string;
   private rerankModel: string;
   private defaultTopK: number;
 
@@ -62,12 +65,17 @@ export class PineconeClient {
   private pc: Pinecone | null = null;
   private denseIndex: SearchableIndex | null = null;
   private sparseIndex: SearchableIndex | null = null;
+  private keywordIndex: SearchableIndex | null = null;
   private initialized = false;
 
   /** Create a client with the given config; env vars override index name, rerank model, and top-k. */
   constructor(config: PineconeClientConfig) {
     this.apiKey = config.apiKey;
     this.indexName = config.indexName || process.env['PINECONE_INDEX_NAME'] || DEFAULT_INDEX_NAME;
+    this.sparseIndexName =
+      config.sparseIndexName ||
+      process.env['PINECONE_SPARSE_INDEX_NAME'] ||
+      DEFAULT_SPARSE_INDEX_NAME;
     this.rerankModel =
       config.rerankModel || process.env['PINECONE_RERANK_MODEL'] || DEFAULT_RERANK_MODEL;
     this.defaultTopK =
@@ -113,6 +121,21 @@ export class PineconeClient {
 
     logInfo(`Connected to indexes: ${denseName} and ${sparseName}`);
     return { denseIndex: dense, sparseIndex: sparse };
+  }
+
+  /**
+   * Ensure the dedicated keyword (sparse-only) index is initialized.
+   * Used by the keyword_search tool to query pinecone-rag-sparse (or configured name).
+   */
+  private async ensureKeywordIndex(): Promise<SearchableIndex> {
+    if (this.keywordIndex !== null) {
+      return this.keywordIndex;
+    }
+    const pc = this.ensureClient();
+    const index = pc.index(this.sparseIndexName) as unknown as SearchableIndex;
+    this.keywordIndex = index;
+    logInfo(`Keyword search index: ${this.sparseIndexName}`);
+    return index;
   }
 
   /**
@@ -450,6 +473,68 @@ export class PineconeClient {
       `Retrieved ${documents.length} documents from hybrid search (dense: ${denseHits.length}, sparse: ${sparseHits.length})`
     );
 
+    return documents;
+  }
+
+  /**
+   * Keyword (sparse-only) search against the dedicated sparse index.
+   * Performs lexical/keyword retrieval only—no dense index, no reranking.
+   * Use for exact or keyword-style queries on the pinecone-rag-sparse index.
+   */
+  async keywordSearch(params: KeywordSearchParams): Promise<SearchResult[]> {
+    const {
+      query,
+      namespace,
+      topK: requestedTopK,
+      metadataFilter,
+      fields: requestedFields,
+    } = params;
+
+    if (!query || !query.trim()) {
+      throw new Error('Query cannot be empty');
+    }
+
+    let topK = requestedTopK !== undefined ? requestedTopK : this.defaultTopK;
+    if (topK < 1) {
+      throw new Error('topK must be at least 1');
+    }
+    if (topK > MAX_TOP_K) {
+      topK = MAX_TOP_K;
+    }
+
+    const keywordIndex = await this.ensureKeywordIndex();
+    const searchOptions = requestedFields?.length ? { fields: requestedFields } : undefined;
+
+    const hits = await this.searchIndex(
+      keywordIndex,
+      query.trim(),
+      topK,
+      namespace,
+      metadataFilter,
+      searchOptions
+    );
+
+    const documents: SearchResult[] = hits.map((hit) => {
+      const fields = hit.fields || {};
+      let content = '';
+      const metadata: Record<string, PineconeMetadataValue> = {};
+      for (const [key, value] of Object.entries(fields)) {
+        if (key === 'chunk_text') {
+          content = typeof value === 'string' ? value : '';
+        } else {
+          metadata[key] = value as PineconeMetadataValue;
+        }
+      }
+      return {
+        id: hit._id || '',
+        content,
+        score: hit._score || 0,
+        metadata,
+        reranked: false,
+      };
+    });
+
+    logInfo(`Keyword search returned ${documents.length} results from ${this.sparseIndexName}`);
     return documents;
   }
 

--- a/src/pinecone-client.ts
+++ b/src/pinecone-client.ts
@@ -29,7 +29,6 @@ import type {
 import {
   DEFAULT_INDEX_NAME,
   DEFAULT_RERANK_MODEL,
-  DEFAULT_SPARSE_INDEX_NAME,
   DEFAULT_TOP_K,
   MAX_TOP_K,
   COUNT_TOP_K,
@@ -57,7 +56,6 @@ function inferMetadataFieldType(value: unknown): string {
 export class PineconeClient {
   private apiKey: string;
   private indexName: string;
-  private sparseIndexName: string;
   private rerankModel: string;
   private defaultTopK: number;
 
@@ -65,26 +63,21 @@ export class PineconeClient {
   private pc: Pinecone | null = null;
   private denseIndex: SearchableIndex | null = null;
   private sparseIndex: SearchableIndex | null = null;
-  private keywordIndex: SearchableIndex | null = null;
   private initialized = false;
 
   /** Create a client with the given config; env vars override index name, rerank model, and top-k. */
   constructor(config: PineconeClientConfig) {
     this.apiKey = config.apiKey;
     this.indexName = config.indexName || process.env['PINECONE_INDEX_NAME'] || DEFAULT_INDEX_NAME;
-    this.sparseIndexName =
-      config.sparseIndexName ||
-      process.env['PINECONE_SPARSE_INDEX_NAME'] ||
-      DEFAULT_SPARSE_INDEX_NAME;
     this.rerankModel =
       config.rerankModel || process.env['PINECONE_RERANK_MODEL'] || DEFAULT_RERANK_MODEL;
     this.defaultTopK =
       config.defaultTopK || parseInt(process.env['PINECONE_TOP_K'] || String(DEFAULT_TOP_K));
   }
 
-  /** Returns the configured sparse index name used for keyword search (runtime value). */
+  /** Returns the sparse index name (same as hybrid sparse: {indexName}-sparse). Used for keyword_search response. */
   getSparseIndexName(): string {
-    return this.sparseIndexName;
+    return `${this.indexName}-sparse`;
   }
 
   /**
@@ -143,31 +136,16 @@ export class PineconeClient {
   }
 
   /**
-   * Ensure the dedicated keyword (sparse-only) index is initialized.
-   * Used by the keyword_search tool to query pinecone-rag-sparse (or configured name).
-   */
-  private async ensureKeywordIndex(): Promise<SearchableIndex> {
-    if (this.keywordIndex !== null) {
-      return this.keywordIndex;
-    }
-    const pc = this.ensureClient();
-    const index = pc.index(this.sparseIndexName) as unknown as SearchableIndex;
-    this.keywordIndex = index;
-    logInfo(`Keyword search index: ${this.sparseIndexName}`);
-    return index;
-  }
-
-  /**
-   * List namespaces present on the keyword (sparse) index used for keyword_search.
+   * List namespaces present on the sparse index (same index used for hybrid sparse and keyword_search).
    * Use this to choose a namespace for sparse-only queries instead of the dense index list.
    */
   async listNamespacesFromKeywordIndex(): Promise<
     Array<{ namespace: string; recordCount: number }>
   > {
     try {
-      const keywordIndex = await this.ensureKeywordIndex();
-      const stats = keywordIndex.describeIndexStats
-        ? await keywordIndex.describeIndexStats()
+      const { sparseIndex } = await this.ensureIndexes();
+      const stats = sparseIndex.describeIndexStats
+        ? await sparseIndex.describeIndexStats()
         : undefined;
       const namespaces = stats?.namespaces ?? {};
       return Object.entries(namespaces).map(([namespace, info]) => ({
@@ -514,7 +492,7 @@ export class PineconeClient {
   /**
    * Keyword (sparse-only) search against the dedicated sparse index.
    * Performs lexical/keyword retrieval only—no dense index, no reranking.
-   * Use for exact or keyword-style queries on the pinecone-rag-sparse index.
+   * Use for exact or keyword-style queries on the configured sparse index.
    */
   async keywordSearch(params: KeywordSearchParams): Promise<SearchResult[]> {
     const {
@@ -531,11 +509,11 @@ export class PineconeClient {
 
     const topK = this.clampTopK(requestedTopK);
 
-    const keywordIndex = await this.ensureKeywordIndex();
+    const { sparseIndex } = await this.ensureIndexes();
     const searchOptions = requestedFields?.length ? { fields: requestedFields } : undefined;
 
     const hits = await this.searchIndex(
-      keywordIndex,
+      sparseIndex,
       query.trim(),
       topK,
       namespace,
@@ -563,7 +541,7 @@ export class PineconeClient {
       };
     });
 
-    logInfo(`Keyword search returned ${documents.length} results from ${this.sparseIndexName}`);
+    logInfo(`Keyword search returned ${documents.length} results from ${this.getSparseIndexName()}`);
     return documents;
   }
 

--- a/src/pinecone-client.ts
+++ b/src/pinecone-client.ts
@@ -541,7 +541,9 @@ export class PineconeClient {
       };
     });
 
-    logInfo(`Keyword search returned ${documents.length} results from ${this.getSparseIndexName()}`);
+    logInfo(
+      `Keyword search returned ${documents.length} results from ${this.getSparseIndexName()}`
+    );
     return documents;
   }
 

--- a/src/pinecone-client.ts
+++ b/src/pinecone-client.ts
@@ -84,6 +84,9 @@ export class PineconeClient {
    * Normalize and clamp topK from request (validates >= 1, caps at MAX_TOP_K).
    */
   private clampTopK(requested: number | undefined): number {
+    if (requested !== undefined && !Number.isFinite(requested)) {
+      throw new Error('topK must be a finite number >= 1');
+    }
     let topK = requested !== undefined ? requested : this.defaultTopK;
     if (topK < 1) {
       throw new Error('topK must be at least 1');
@@ -123,7 +126,7 @@ export class PineconeClient {
 
     const pc = this.ensureClient();
     const denseName = this.indexName;
-    const sparseName = `${this.indexName}-sparse`;
+    const sparseName = this.getSparseIndexName();
 
     const dense = pc.index(denseName) as unknown as SearchableIndex;
     const sparse = pc.index(sparseName) as unknown as SearchableIndex;

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import { SERVER_INSTRUCTIONS, SERVER_NAME, SERVER_VERSION } from './constants.js
 import { registerCountTool } from './server/tools/count-tool.js';
 import { registerGuidedQueryTool } from './server/tools/guided-query-tool.js';
 import { registerGenerateUrlsTool } from './server/tools/generate-urls-tool.js';
+import { registerKeywordSearchTool } from './server/tools/keyword-search-tool.js';
 import { registerListNamespacesTool } from './server/tools/list-namespaces-tool.js';
 import { registerNamespaceRouterTool } from './server/tools/namespace-router-tool.js';
 import { registerQueryDocumentsTool } from './server/tools/query-documents-tool.js';
@@ -38,6 +39,7 @@ export async function setupServer(): Promise<McpServer> {
   registerSuggestQueryParamsTool(server);
   registerCountTool(server);
   registerQueryTool(server);
+  registerKeywordSearchTool(server);
   registerQueryDocumentsTool(server);
   registerGuidedQueryTool(server);
   registerGenerateUrlsTool(server);

--- a/src/server/tools/keyword-search-tool.ts
+++ b/src/server/tools/keyword-search-tool.ts
@@ -1,0 +1,138 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { DEFAULT_SPARSE_INDEX_NAME, MAX_TOP_K, MIN_TOP_K } from '../../constants.js';
+import { getPineconeClient } from '../client-context.js';
+import { formatQueryResultRows } from '../format-query-result.js';
+import { metadataFilterSchema, validateMetadataFilter } from '../metadata-filter.js';
+import { getToolErrorMessage, logToolError } from '../tool-error.js';
+import { jsonErrorResponse, jsonResponse } from '../tool-response.js';
+
+/** Response shape for keyword_search: same as query tool for consistency. */
+export interface KeywordSearchResponse {
+  status: 'success' | 'error';
+  query?: string;
+  namespace?: string;
+  index?: string;
+  metadata_filter?: Record<string, unknown>;
+  result_count?: number;
+  results?: Array<{
+    paper_number: string | null;
+    title: string;
+    author: string;
+    url: string;
+    content: string;
+    score: number;
+    reranked: boolean;
+    metadata?: Record<string, unknown>;
+  }>;
+  fields?: string[];
+  message?: string;
+}
+
+async function executeKeywordSearch(params: {
+  query_text: string;
+  namespace: string;
+  top_k: number;
+  metadata_filter?: Record<string, unknown>;
+  fields?: string[];
+}): Promise<KeywordSearchResponse> {
+  const { query_text, namespace, top_k, metadata_filter, fields } = params;
+
+  if (!query_text.trim()) {
+    return {
+      status: 'error',
+      message: 'Query text cannot be empty',
+    };
+  }
+
+  if (metadata_filter) {
+    const filterError = validateMetadataFilter(metadata_filter);
+    if (filterError) {
+      return { status: 'error', message: filterError };
+    }
+  }
+
+  const client = getPineconeClient();
+  const results = await client.keywordSearch({
+    query: query_text.trim(),
+    namespace,
+    topK: top_k,
+    metadataFilter: metadata_filter,
+    fields: fields?.length ? fields : undefined,
+  });
+
+  const formattedResults = formatQueryResultRows(results, { namespace });
+
+  const response: KeywordSearchResponse = {
+    status: 'success',
+    query: query_text,
+    namespace,
+    index: DEFAULT_SPARSE_INDEX_NAME,
+    metadata_filter: metadata_filter,
+    result_count: formattedResults.length,
+    results: formattedResults,
+  };
+  if (fields?.length) {
+    response.fields = fields;
+  }
+  return response;
+}
+
+/** Register the keyword_search tool on the MCP server. */
+export function registerKeywordSearchTool(server: McpServer): void {
+  server.registerTool(
+    'keyword_search',
+    {
+      description:
+        'Keyword (lexical/sparse-only) search over the Pinecone sparse index (e.g. pinecone-rag-sparse). ' +
+        'Use for exact or keyword-style queries. Does not use semantic reranking. ' +
+        'Call list_namespaces first to discover namespaces; suggest_query_params is optional.',
+      inputSchema: {
+        query_text: z.string().describe('Search query text (keyword/lexical match).'),
+        namespace: z
+          .string()
+          .describe(
+            'Namespace to search. Use list_namespaces to discover available namespaces.'
+          ),
+        top_k: z
+          .number()
+          .int()
+          .min(MIN_TOP_K)
+          .max(MAX_TOP_K)
+          .default(10)
+          .describe('Number of results to return (1-100). Default: 10'),
+        metadata_filter: metadataFilterSchema
+          .optional()
+          .describe('Optional metadata filter to narrow results.'),
+        fields: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Optional field names to return. Omit for all fields; use suggest_query_params for suggestions.'
+          ),
+      },
+    },
+    async (params) => {
+      try {
+        const response = await executeKeywordSearch({
+          query_text: params.query_text,
+          namespace: params.namespace,
+          top_k: params.top_k ?? 10,
+          metadata_filter: params.metadata_filter,
+          fields: params.fields,
+        });
+        if (response.status === 'error') {
+          return jsonErrorResponse(response);
+        }
+        return jsonResponse(response);
+      } catch (error) {
+        logToolError('keyword_search', error);
+        const response: KeywordSearchResponse = {
+          status: 'error',
+          message: getToolErrorMessage(error, 'Keyword search failed'),
+        };
+        return jsonErrorResponse(response);
+      }
+    }
+  );
+}

--- a/src/server/tools/keyword-search-tool.ts
+++ b/src/server/tools/keyword-search-tool.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { DEFAULT_SPARSE_INDEX_NAME, MAX_TOP_K, MIN_TOP_K } from '../../constants.js';
+import { MAX_TOP_K, MIN_TOP_K } from '../../constants.js';
 import { getPineconeClient } from '../client-context.js';
 import { formatQueryResultRows } from '../format-query-result.js';
 import { metadataFilterSchema, validateMetadataFilter } from '../metadata-filter.js';
@@ -67,7 +67,7 @@ async function executeKeywordSearch(params: {
     status: 'success',
     query: query_text,
     namespace,
-    index: DEFAULT_SPARSE_INDEX_NAME,
+    index: client.getSparseIndexName(),
     metadata_filter: metadata_filter,
     result_count: formattedResults.length,
     results: formattedResults,
@@ -91,9 +91,7 @@ export function registerKeywordSearchTool(server: McpServer): void {
         query_text: z.string().describe('Search query text (keyword/lexical match).'),
         namespace: z
           .string()
-          .describe(
-            'Namespace to search. Use list_namespaces to discover available namespaces.'
-          ),
+          .describe('Namespace to search. Use list_namespaces to discover available namespaces.'),
         top_k: z
           .number()
           .int()
@@ -117,7 +115,7 @@ export function registerKeywordSearchTool(server: McpServer): void {
         const response = await executeKeywordSearch({
           query_text: params.query_text,
           namespace: params.namespace,
-          top_k: params.top_k ?? 10,
+          top_k: params.top_k,
           metadata_filter: params.metadata_filter,
           fields: params.fields,
         });

--- a/src/server/tools/keyword-search-tool.ts
+++ b/src/server/tools/keyword-search-tool.ts
@@ -84,7 +84,7 @@ export function registerKeywordSearchTool(server: McpServer): void {
     'keyword_search',
     {
       description:
-        'Keyword (lexical/sparse-only) search over the Pinecone sparse index (e.g. pinecone-rag-sparse). ' +
+        'Keyword (lexical/sparse-only) search over the Pinecone sparse index (default: rag-hybrid-sparse). ' +
         'Use for exact or keyword-style queries. Does not use semantic reranking. ' +
         'Call list_namespaces first to discover namespaces; suggest_query_params is optional.',
       inputSchema: {

--- a/src/server/tools/keyword-search-tool.ts
+++ b/src/server/tools/keyword-search-tool.ts
@@ -38,10 +38,20 @@ async function executeKeywordSearch(params: {
 }): Promise<KeywordSearchResponse> {
   const { query_text, namespace, top_k, metadata_filter, fields } = params;
 
-  if (!query_text.trim()) {
+  const normalizedQuery = query_text.trim();
+  const normalizedNamespace = namespace?.trim() ?? '';
+
+  if (!normalizedQuery) {
     return {
       status: 'error',
       message: 'Query text cannot be empty',
+    };
+  }
+
+  if (!normalizedNamespace) {
+    return {
+      status: 'error',
+      message: 'Namespace cannot be empty',
     };
   }
 
@@ -54,19 +64,21 @@ async function executeKeywordSearch(params: {
 
   const client = getPineconeClient();
   const results = await client.keywordSearch({
-    query: query_text.trim(),
-    namespace,
+    query: normalizedQuery,
+    namespace: normalizedNamespace,
     topK: top_k,
     metadataFilter: metadata_filter,
     fields: fields?.length ? fields : undefined,
   });
 
-  const formattedResults = formatQueryResultRows(results, { namespace });
+  const formattedResults = formatQueryResultRows(results, {
+    namespace: normalizedNamespace,
+  });
 
   const response: KeywordSearchResponse = {
     status: 'success',
-    query: query_text,
-    namespace,
+    query: normalizedQuery,
+    namespace: normalizedNamespace,
     index: client.getSparseIndexName(),
     metadata_filter: metadata_filter,
     result_count: formattedResults.length,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export type PineconeMetadataValue = string | number | boolean | string[];
 export interface PineconeClientConfig {
   apiKey: string;
   indexName?: string;
+  /** Dedicated sparse index for keyword_search tool (e.g. pinecone-rag-sparse). */
+  sparseIndexName?: string;
   rerankModel?: string;
   defaultTopK?: number;
 }
@@ -51,6 +53,16 @@ export interface CountParams {
   query: string;
   namespace: string;
   metadataFilter?: Record<string, unknown>;
+}
+
+/** Parameters for keyword (sparse-only) search against the dedicated sparse index. */
+export interface KeywordSearchParams {
+  query: string;
+  namespace: string;
+  topK?: number;
+  metadataFilter?: Record<string, unknown>;
+  /** If set, only these fields are returned. Omit for all fields. */
+  fields?: string[];
 }
 
 /** Result of a count request: unique document count (deduped by doc id/url); truncated when at least COUNT_TOP_K. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,6 @@ export type PineconeMetadataValue = string | number | boolean | string[];
 export interface PineconeClientConfig {
   apiKey: string;
   indexName?: string;
-  /** Dedicated sparse index for keyword_search tool (e.g. pinecone-rag-sparse). */
-  sparseIndexName?: string;
   rerankModel?: string;
   defaultTopK?: number;
 }


### PR DESCRIPTION
Closes #29 
feat: add keyword_search tool for pinecone-rag-sparse index (#29)

- Add PineconeClient.keywordSearch() for sparse-only (lexical) search
- Register keyword_search MCP tool (query_text, namespace, top_k, optional metadata_filter, fields)
- Config: PINECONE_SPARSE_INDEX_NAME / --sparse-index-name (default: pinecone-rag-sparse)
- Document tool in README; add Test 5 in scripts/test-search.ts
- No reranking; returns same result shape as query tool (reranked: false)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyword_search capability (sparse-index, no semantic rerank), sparse-namespace listing, and a server/API tool for keyword-only queries; CLI shows sparse-index info.
* **Documentation**
  * Expanded README and API docs with keyword_search parameters, examples, testing steps, and updated CLI/env option descriptions.
* **Tests**
  * Added an automated keyword_search test with timing, result logging, and guidance when sparse namespaces are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->