### PR TITLE
updated descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules/
 
 # Build outputs
 dist/
-data/
 build/
 *.tsbuildinfo
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 
 # Build outputs
 dist/
+data/
 build/
 *.tsbuildinfo
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ Discovers and lists all available namespaces in the configured Pinecone index, i
 }
 ```
 
+### Retrieval tool decision matrix
+
+Use this when choosing among overlapping retrieval tools. **Semantic vs lexical:** use `query` / `query_fast` / `query_detailed` or `query_documents` for meaning-based search; use `keyword_search` for exact or keyword-style matches on the sparse index. **Chunks vs whole documents:** use `query` / `query_fast` / `query_detailed` for ranked chunks; use `query_documents` when you need merged full-document text. **One-shot vs manual flow:** use `guided_query` to run routing, suggestion, and execution in a single call; otherwise call `suggest_query_params` before gated tools.
+
+- **`query` / `query_fast` / `query_detailed`** — Semantic chunk retrieval. Requires `suggest_query_params` to be called first for the target namespace.
+- **`query_documents`** — Semantic search with chunks reassembled into whole documents. Requires `suggest_query_params` to be called first for the target namespace.
+- **`keyword_search`** — Lexical (sparse-only) search. Does not require `suggest_query_params`.
+- **`guided_query`** — Combines namespace routing, suggestion, and query into a single call; no prerequisite tools needed.
+- **`count`** — “How many …?” style counts via semantic search. Requires `suggest_query_params` before use (same gate as `query` / `query_documents`).
+
 ### `suggest_query_params`
 
 Suggests which **fields** to request and which tool to use (`count`, `query_fast`, or `query_detailed`), based on the namespace’s schema (from `list_namespaces`) and the user’s natural language query. This is a mandatory flow step before `count`/`query` tools.

--- a/src/server/tools/guided-query-tool.ts
+++ b/src/server/tools/guided-query-tool.ts
@@ -35,7 +35,7 @@ export function registerGuidedQueryTool(server: McpServer): void {
     {
       description:
         'Combines namespace routing, suggestion, and query into a single call — no prerequisite tools needed. ' +
-        'Single orchestrator: optional namespace_router logic -> executes count/query/query_fast/query_detailed (query is used for full mode). ' +
+        'Single orchestrator: optional namespace_router logic -> executes count or hybrid query (fast / detailed / full presets). ' +
         'Returns decision_trace so behavior stays transparent and debuggable.',
       inputSchema: {
         user_query: z.string().describe('User question or intent.'),

--- a/src/server/tools/guided-query-tool.ts
+++ b/src/server/tools/guided-query-tool.ts
@@ -14,14 +14,17 @@ import { jsonErrorResponse, jsonResponse } from '../tool-response.js';
 
 type GuidedToolName = 'count' | 'query_fast' | 'query_detailed';
 
-/** Register the guided_query orchestrator tool on the MCP server. */
+/**
+ * Registers `guided_query` (routing + suggestion + execution in one call).
+ * See "Retrieval tool decision matrix" in README.md for tool-selection guidance.
+ */
 export function registerGuidedQueryTool(server: McpServer): void {
   server.registerTool(
     'guided_query',
     {
       description:
-        'Single orchestrator that runs routing + suggestion + execution in one call. ' +
-        'Flow: optional namespace_router logic -> suggest_query_params logic -> executes count/query_fast/query_detailed. ' +
+        'Combines namespace routing, suggestion, and query into a single call — no prerequisite tools needed. ' +
+        'Single orchestrator: optional namespace_router logic -> suggest_query_params logic -> executes count/query_fast/query_detailed. ' +
         'Returns decision_trace so behavior stays transparent and debuggable.',
       inputSchema: {
         user_query: z.string().describe('User question or intent.'),

--- a/src/server/tools/guided-query-tool.ts
+++ b/src/server/tools/guided-query-tool.ts
@@ -35,7 +35,7 @@ export function registerGuidedQueryTool(server: McpServer): void {
     {
       description:
         'Combines namespace routing, suggestion, and query into a single call — no prerequisite tools needed. ' +
-        'Single orchestrator: optional namespace_router logic -> suggest_query_params logic -> executes count/query_fast/query_detailed. ' +
+        'Single orchestrator: optional namespace_router logic -> executes count/query/query_fast/query_detailed (query is used for full mode). ' +
         'Returns decision_trace so behavior stays transparent and debuggable.',
       inputSchema: {
         user_query: z.string().describe('User question or intent.'),

--- a/src/server/tools/keyword-search-tool.ts
+++ b/src/server/tools/keyword-search-tool.ts
@@ -90,7 +90,10 @@ async function executeKeywordSearch(params: {
   return response;
 }
 
-/** Register the keyword_search tool on the MCP server. */
+/**
+ * Registers `keyword_search` (lexical/sparse-only retrieval).
+ * See "Retrieval tool decision matrix" in README.md for tool-selection guidance.
+ */
 export function registerKeywordSearchTool(server: McpServer): void {
   server.registerTool(
     'keyword_search',
@@ -98,7 +101,7 @@ export function registerKeywordSearchTool(server: McpServer): void {
       description:
         'Keyword (lexical/sparse-only) search over the Pinecone sparse index (default: rag-hybrid-sparse). ' +
         'Use for exact or keyword-style queries. Does not use semantic reranking. ' +
-        'Call list_namespaces first to discover namespaces; suggest_query_params is optional.',
+        'Call list_namespaces first to discover namespaces. Does not require suggest_query_params.',
       inputSchema: {
         query_text: z.string().describe('Search query text (keyword/lexical match).'),
         namespace: z

--- a/src/server/tools/query-documents-tool.ts
+++ b/src/server/tools/query-documents-tool.ts
@@ -21,7 +21,10 @@ import { jsonErrorResponse, jsonResponse } from '../tool-response.js';
  */
 const CHUNKS_PER_DOCUMENT = 50;
 
-/** Register the query_documents tool (reassemble chunks into full documents) on the MCP server. */
+/**
+ * Registers `query_documents` (reassemble chunks into full documents).
+ * See "Retrieval tool decision matrix" in README.md for tool-selection guidance.
+ */
 export function registerQueryDocumentsTool(server: McpServer): void {
   server.registerTool(
     'query_documents',
@@ -30,7 +33,7 @@ export function registerQueryDocumentsTool(server: McpServer): void {
         'Run a semantic query and return whole documents (reassembled from chunks). ' +
         'Use for content analysis, summarization, or when you need full-document context. ' +
         'Chunks are grouped by document_number/doc_id/url, ordered by chunk_index when present (e.g. from RecursiveCharacterTextSplitter), and merged into one content per document. ' +
-        'Mandatory flow: call suggest_query_params first. Use list_namespaces to discover namespaces.',
+        'Requires suggest_query_params to be called first for the target namespace. Use list_namespaces to discover namespaces.',
       inputSchema: {
         query_text: z.string().describe('Search query text. Be specific for better results.'),
         namespace: z

--- a/src/server/tools/query-tool.ts
+++ b/src/server/tools/query-tool.ts
@@ -108,7 +108,7 @@ const baseSchema = {
 };
 
 /**
- * Registers semantic chunk query tools (`query`, `query_fast`, `query_detailed`).
+ * Registers semantic chunk query via one preset-driven `query` tool.
  * See "Retrieval tool decision matrix" in README.md for tool-selection guidance.
  */
 export function registerQueryTool(server: McpServer): void {
@@ -116,69 +116,52 @@ export function registerQueryTool(server: McpServer): void {
     'query',
     {
       description:
-        'Full query tool with optional reranking. Requires suggest_query_params to be called first for the target namespace. ' +
-        'For lighter retrieval use query_fast; for content-heavy retrieval use query_detailed.',
+        'Hybrid semantic search (dense + sparse) with optional reranking. Requires suggest_query_params to be called first for the target namespace. ' +
+        'Use preset=`fast` for low-latency retrieval without reranking and lightweight fields; `detailed` for reranked, content-oriented retrieval; `full` to set use_reranking and fields explicitly.',
       inputSchema: {
         ...baseSchema,
+        preset: z
+          .enum(['fast', 'detailed', 'full'])
+          .default('full')
+          .describe(
+            'fast: no reranking + lightweight fields (former query_fast). detailed: reranking on (former query_detailed). full: use use_reranking and fields below.'
+          ),
         use_reranking: z
           .boolean()
-          .default(true)
+          .optional()
           .describe(
-            'Whether to use semantic reranking for better relevance. Slower but more accurate.'
+            'Used when preset is detailed or full (default true). Ignored when preset is fast.'
           ),
       },
     },
     async (params) => {
-      return executeQuery({
-        ...params,
-        top_k: params.top_k,
-        use_reranking: params.use_reranking,
-        mode: 'query',
-      });
-    }
-  );
+      const preset = params.preset;
+      let use_reranking: boolean;
+      let fields: string[] | undefined;
+      let mode: QueryMode;
 
-  server.registerTool(
-    'query_fast',
-    {
-      description:
-        'Fast query preset. Requires suggest_query_params to be called first for the target namespace. ' +
-        'Defaults to no reranking and lightweight fields for lower latency/cost.',
-      inputSchema: {
-        ...baseSchema,
-      },
-    },
-    async (params) => {
-      return executeQuery({
-        ...params,
-        top_k: params.top_k,
-        use_reranking: false,
-        fields: params.fields?.length ? params.fields : [...FAST_QUERY_FIELDS],
-        mode: 'query_fast',
-      });
-    }
-  );
+      if (preset === 'fast') {
+        use_reranking = false;
+        fields = params.fields?.length ? params.fields : [...FAST_QUERY_FIELDS];
+        mode = 'query_fast';
+      } else if (preset === 'detailed') {
+        use_reranking = params.use_reranking ?? true;
+        fields = params.fields?.length ? params.fields : undefined;
+        mode = 'query_detailed';
+      } else {
+        use_reranking = params.use_reranking ?? true;
+        fields = params.fields?.length ? params.fields : undefined;
+        mode = 'query';
+      }
 
-  server.registerTool(
-    'query_detailed',
-    {
-      description:
-        'Detailed query preset. Requires suggest_query_params to be called first for the target namespace. ' +
-        'Designed for reading/summarization workflows with content snippets.',
-      inputSchema: {
-        ...baseSchema,
-        use_reranking: z
-          .boolean()
-          .default(true)
-          .describe('Whether to use semantic reranking for better precision (default true).'),
-      },
-    },
-    async (params) => {
       return executeQuery({
-        ...params,
-        top_k: params.top_k ?? 10,
-        use_reranking: params.use_reranking ?? true,
-        mode: 'query_detailed',
+        query_text: params.query_text,
+        namespace: params.namespace,
+        top_k: params.top_k,
+        use_reranking,
+        metadata_filter: params.metadata_filter,
+        fields,
+        mode,
       });
     }
   );

--- a/src/server/tools/query-tool.ts
+++ b/src/server/tools/query-tool.ts
@@ -128,13 +128,14 @@ export function registerQueryTool(server: McpServer): void {
           ),
       },
     },
-    async (params) =>
-      executeQuery({
+    async (params) => {
+      return executeQuery({
         ...params,
         top_k: params.top_k,
         use_reranking: params.use_reranking,
         mode: 'query',
-      })
+      });
+    }
   );
 
   server.registerTool(
@@ -147,14 +148,15 @@ export function registerQueryTool(server: McpServer): void {
         ...baseSchema,
       },
     },
-    async (params) =>
-      executeQuery({
+    async (params) => {
+      return executeQuery({
         ...params,
         top_k: params.top_k,
         use_reranking: false,
         fields: params.fields?.length ? params.fields : [...FAST_QUERY_FIELDS],
         mode: 'query_fast',
-      })
+      });
+    }
   );
 
   server.registerTool(
@@ -171,12 +173,13 @@ export function registerQueryTool(server: McpServer): void {
           .describe('Whether to use semantic reranking for better precision (default true).'),
       },
     },
-    async (params) =>
-      executeQuery({
+    async (params) => {
+      return executeQuery({
         ...params,
         top_k: params.top_k ?? 10,
         use_reranking: params.use_reranking ?? true,
         mode: 'query_detailed',
-      })
+      });
+    }
   );
 }

--- a/src/server/tools/query-tool.ts
+++ b/src/server/tools/query-tool.ts
@@ -107,13 +107,16 @@ const baseSchema = {
     ),
 };
 
-/** Register the unified query tool (query_fast / query_detailed) on the MCP server. */
+/**
+ * Registers semantic chunk query tools (`query`, `query_fast`, `query_detailed`).
+ * See "Retrieval tool decision matrix" in README.md for tool-selection guidance.
+ */
 export function registerQueryTool(server: McpServer): void {
   server.registerTool(
     'query',
     {
       description:
-        'Full query tool with optional reranking. Mandatory flow: call suggest_query_params first. ' +
+        'Full query tool with optional reranking. Requires suggest_query_params to be called first for the target namespace. ' +
         'For lighter retrieval use query_fast; for content-heavy retrieval use query_detailed.',
       inputSchema: {
         ...baseSchema,
@@ -138,7 +141,7 @@ export function registerQueryTool(server: McpServer): void {
     'query_fast',
     {
       description:
-        'Fast query preset. Mandatory flow: call suggest_query_params first. ' +
+        'Fast query preset. Requires suggest_query_params to be called first for the target namespace. ' +
         'Defaults to no reranking and lightweight fields for lower latency/cost.',
       inputSchema: {
         ...baseSchema,
@@ -158,7 +161,7 @@ export function registerQueryTool(server: McpServer): void {
     'query_detailed',
     {
       description:
-        'Detailed query preset. Mandatory flow: call suggest_query_params first. ' +
+        'Detailed query preset. Requires suggest_query_params to be called first for the target namespace. ' +
         'Designed for reading/summarization workflows with content snippets.',
       inputSchema: {
         ...baseSchema,


### PR DESCRIPTION
## MCP description updates

- src/server/tools/query-tool.ts — query, query_fast, and query_detailed now include: Requires suggest_query_params to be called first for the target namespace.
- src/server/tools/query-documents-tool.ts — Same sentence for query_documents.
- src/server/tools/keyword-search-tool.ts — Does not require suggest_query_params (with a trailing period on the sentence).
- src/server/tools/guided-query-tool.ts — Opens with: Combines namespace routing, suggestion, and query into a single call — no prerequisite tools needed. (em dash as in the issue), then the existing orchestrator / decision_trace text.

## JSDoc pointers

Each of the four register*Tool functions now has a short block comment pointing at "Retrieval tool decision matrix" in README.md.

## README

New README.md subsection Retrieval tool decision matrix (before ### suggest_query_params) with the two-line decision guide and bullets for query / query_fast / query_detailed, query_documents, keyword_search, guided_query, and count.

## Verification

- npm run build completed successfully.
- Grep confirms the required phrases appear in the intended tool files.
- No new linter issues on the edited .ts files.

close https://github.com/cppalliance/pinecone-read-only-mcp-typescript/issues/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a retrieval tool decision matrix to README, providing guidance on selecting the appropriate retrieval tool based on search type, scope, and execution flow.
  * Enhanced tool descriptions across the retrieval tool suite to clarify capabilities and prerequisite requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/pinecone-read-only-mcp-typescript/pull/81)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->