### PR TITLE
fixed reassemble and query format module

### DIFF
--- a/src/server/format-query-result.test.ts
+++ b/src/server/format-query-result.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as loggerModule from '../logger.js';
+import type { SearchResult } from '../types.js';
+import {
+  formatQueryResultRows,
+  formatSearchResultAsRow,
+  resetPaperNumberDeprecationLatchForTests,
+} from './format-query-result.js';
+
+const DEPRECATION_SUBSTRING =
+  'paper_number is deprecated and will be removed in the next major release';
+
+describe('formatSearchResultAsRow / formatQueryResultRows', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetPaperNumberDeprecationLatchForTests();
+    warnSpy = vi.spyOn(loggerModule, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns once on first row even when document_id is null', () => {
+    const doc: SearchResult = {
+      id: 'v1',
+      content: 'hello world',
+      score: 0.99,
+      metadata: { title: 'T' },
+      reranked: false,
+    };
+    const row = formatSearchResultAsRow(doc);
+    expect(row.document_id).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain(DEPRECATION_SUBSTRING);
+  });
+
+  it('does not warn again on second formatSearchResultAsRow call', () => {
+    const doc: SearchResult = {
+      id: 'v1',
+      content: 'a',
+      score: 0.5,
+      metadata: { document_number: 'P1' },
+      reranked: false,
+    };
+    formatSearchResultAsRow(doc);
+    formatSearchResultAsRow(doc);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns at most once for formatQueryResultRows with multiple hits', () => {
+    const results: SearchResult[] = [
+      {
+        id: 'a',
+        content: 'one',
+        score: 0.9,
+        metadata: { document_number: 'D1' },
+        reranked: false,
+      },
+      {
+        id: 'b',
+        content: 'two',
+        score: 0.8,
+        metadata: { document_number: 'D2' },
+        reranked: false,
+      },
+    ];
+    formatQueryResultRows(results);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/format-query-result.ts
+++ b/src/server/format-query-result.ts
@@ -21,8 +21,9 @@ export interface QueryResultRow {
   document_id: string | null;
   /**
    * @deprecated Use `document_id`. Kept for one minor cycle and removed in
-   * the next major release. The first time a row is emitted with this alias
-   * during a session, a `WARN` log is fired so consumers see the deadline.
+   * the next major release. The first formatted query-result row in the
+   * process triggers a single `WARN` log per session so consumers see the
+   * deprecation deadline.
    */
   paper_number: string | null;
   title: string;
@@ -79,7 +80,7 @@ export function formatSearchResultAsRow(
       : null) ??
     null;
 
-  if (document_id !== null && !deprecationWarnedThisSession) {
+  if (!deprecationWarnedThisSession) {
     deprecationWarnedThisSession = true;
     logWarn(
       'paper_number is deprecated and will be removed in the next major release; use document_id instead.'

--- a/src/server/reassemble-documents.test.ts
+++ b/src/server/reassemble-documents.test.ts
@@ -176,18 +176,22 @@ describe('reassembleByDocument', () => {
     expect(warnSpy.mock.calls[0]?.[0]).toMatch(/sample_ids=<empty>/);
   });
 
-  it('includes sample vector ids in skip warning up to limit', () => {
-    const emptyDocNum = { document_number: '' } as Record<string, string>;
-    const results: SearchResult[] = [
-      { id: 'a', content: 'x', score: 0.1, metadata: emptyDocNum, reranked: false },
-      { id: 'b', content: 'y', score: 0.2, metadata: emptyDocNum, reranked: false },
-      { id: 'c', content: 'z', score: 0.3, metadata: emptyDocNum, reranked: false },
-      { id: 'd', content: 'w', score: 0.4, metadata: emptyDocNum, reranked: false },
-    ];
+  it('includes at most three sample entries in skip warning when many hits are skipped', () => {
+    const results: SearchResult[] = Array.from({ length: 4 }, (_, i) => ({
+      id: '',
+      content: `chunk-${i}`,
+      score: 0.1 * (i + 1),
+      metadata: {},
+      reranked: false,
+    }));
     reassembleByDocument(results);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const msg = String(warnSpy.mock.calls[0]?.[0]);
     expect(msg).toMatch(/skipped 4 hit/);
-    expect(msg.match(/sample_ids=([^\s.]+)/)?.[1]).toBe('a,b,c');
+    const samplePart = msg.match(/sample_ids=(.+)$/)?.[1];
+    expect(samplePart).toBeDefined();
+    const samples = samplePart!.split(',');
+    expect(samples).toHaveLength(3);
+    expect(samples.every((s) => s === '<empty>')).toBe(true);
   });
 });

--- a/src/server/reassemble-documents.test.ts
+++ b/src/server/reassemble-documents.test.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as loggerModule from '../logger.js';
 import { reassembleByDocument } from './reassemble-documents.js';
 import type { SearchResult } from '../types.js';
 
 describe('reassembleByDocument', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(loggerModule, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it('groups chunks by document_number', () => {
     const results: SearchResult[] = [
       {
@@ -84,5 +95,99 @@ describe('reassembleByDocument', () => {
     expect(docs).toHaveLength(1);
     expect(docs[0].chunk_count).toBe(3);
     expect(docs[0].merged_content).toBe('Chunk 0\n\nChunk 1\n\nChunk 2');
+  });
+
+  it('does not warn when all hits have a document key', () => {
+    const results: SearchResult[] = [
+      {
+        id: 'c1',
+        content: 'Only doc.',
+        score: 0.9,
+        metadata: { document_number: 'P1' },
+        reranked: false,
+      },
+    ];
+    reassembleByDocument(results);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns once with count when hits lack document key and empty vector id', () => {
+    const results: SearchResult[] = [
+      {
+        id: '',
+        content: 'Orphan chunk.',
+        score: 0.5,
+        metadata: {},
+        reranked: false,
+      },
+    ];
+    const docs = reassembleByDocument(results);
+    expect(docs).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/skipped 1 hit/);
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/sample_ids=<empty>/);
+  });
+
+  it('aggregates multiple skipped hits into one warn with total count', () => {
+    const results: SearchResult[] = [
+      {
+        id: '',
+        content: 'A',
+        score: 0.5,
+        metadata: {},
+        reranked: false,
+      },
+      {
+        id: '',
+        content: 'B',
+        score: 0.4,
+        metadata: {},
+        reranked: false,
+      },
+    ];
+    const docs = reassembleByDocument(results);
+    expect(docs).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/skipped 2 hit/);
+  });
+
+  it('warns only for invalid hits when mixed with valid document keys', () => {
+    const results: SearchResult[] = [
+      {
+        id: '',
+        content: 'Skipped.',
+        score: 0.3,
+        metadata: {},
+        reranked: false,
+      },
+      {
+        id: 'vec-1',
+        content: 'Kept by id.',
+        score: 0.9,
+        metadata: {},
+        reranked: false,
+      },
+    ];
+    const docs = reassembleByDocument(results);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].document_id).toBe('vec-1');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/skipped 1 hit/);
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/sample_ids=<empty>/);
+  });
+
+  it('includes sample vector ids in skip warning up to limit', () => {
+    const emptyDocNum = { document_number: '' } as Record<string, string>;
+    const results: SearchResult[] = [
+      { id: 'a', content: 'x', score: 0.1, metadata: emptyDocNum, reranked: false },
+      { id: 'b', content: 'y', score: 0.2, metadata: emptyDocNum, reranked: false },
+      { id: 'c', content: 'z', score: 0.3, metadata: emptyDocNum, reranked: false },
+      { id: 'd', content: 'w', score: 0.4, metadata: emptyDocNum, reranked: false },
+    ];
+    reassembleByDocument(results);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = String(warnSpy.mock.calls[0]?.[0]);
+    expect(msg).toMatch(/skipped 4 hit/);
+    expect(msg.match(/sample_ids=([^\s.]+)/)?.[1]).toBe('a,b,c');
   });
 });

--- a/src/server/reassemble-documents.ts
+++ b/src/server/reassemble-documents.ts
@@ -93,8 +93,7 @@ export function reassembleByDocument(
   }
 
   if (skippedHits > 0) {
-    const sample =
-      sampleIdsForWarn.length > 0 ? ` sample_ids=${sampleIdsForWarn.join(',')}` : '';
+    const sample = sampleIdsForWarn.length > 0 ? ` sample_ids=${sampleIdsForWarn.join(',')}` : '';
     logWarn(
       `reassembleByDocument: skipped ${skippedHits} hit(s) with no document key (document_number, url, doc_id, or non-empty vector id).${sample}`
     );

--- a/src/server/reassemble-documents.ts
+++ b/src/server/reassemble-documents.ts
@@ -22,13 +22,7 @@ function getDocumentKey(hit: SearchResult): string {
   const nonEmpty = (v: unknown): string | undefined =>
     typeof v === 'string' && v.trim() !== '' ? v : undefined;
 
-  return (
-    nonEmpty(docNumber) ??
-    nonEmpty(url) ??
-    nonEmpty(docId) ??
-    nonEmpty(hit.id) ??
-    ''
-  );
+  return nonEmpty(docNumber) ?? nonEmpty(url) ?? nonEmpty(docId) ?? nonEmpty(hit.id) ?? '';
 }
 
 /** Return a numeric order for sorting chunks from metadata (chunk_index, start_index, or loc). */

--- a/src/server/reassemble-documents.ts
+++ b/src/server/reassemble-documents.ts
@@ -19,11 +19,14 @@ function getDocumentKey(hit: SearchResult): string {
   const docNumber = m['document_number'];
   const url = m['url'];
   const docId = m['doc_id'];
+  const nonEmpty = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.trim() !== '' ? v : undefined;
+
   return (
-    (typeof docNumber === 'string' ? docNumber : undefined) ??
-    (typeof url === 'string' ? url : undefined) ??
-    (typeof docId === 'string' ? docId : undefined) ??
-    hit.id ??
+    nonEmpty(docNumber) ??
+    nonEmpty(url) ??
+    nonEmpty(docId) ??
+    nonEmpty(hit.id) ??
     ''
   );
 }

--- a/src/server/reassemble-documents.ts
+++ b/src/server/reassemble-documents.ts
@@ -5,9 +5,13 @@
  */
 
 import type { PineconeMetadataValue, SearchResult } from '../types.js';
+import { warn as logWarn } from '../logger.js';
 
 /** Default metadata keys tried for chunk ordering (RecursiveCharacterTextSplitter often adds these). */
 const CHUNK_ORDER_KEYS = ['chunk_index', 'start_index', 'loc'] as const;
+
+/** Max vector ids listed in the one-per-call skip warning (for grep-friendly debugging). */
+const SKIP_WARN_SAMPLE_IDS = 3;
 
 /** Derive a stable document key from hit metadata: document_number → url → doc_id → hit.id. */
 function getDocumentKey(hit: SearchResult): string {
@@ -68,16 +72,32 @@ export function reassembleByDocument(
   const separator = options?.contentSeparator ?? '\n\n';
 
   const byDoc = new Map<string, SearchResult[]>();
+  let skippedHits = 0;
+  const sampleIdsForWarn: string[] = [];
 
   for (const hit of results) {
     const key = getDocumentKey(hit);
-    if (!key) continue;
+    if (!key) {
+      skippedHits++;
+      if (sampleIdsForWarn.length < SKIP_WARN_SAMPLE_IDS) {
+        sampleIdsForWarn.push(hit.id.trim() === '' ? '<empty>' : hit.id);
+      }
+      continue;
+    }
     let list = byDoc.get(key);
     if (!list) {
       list = [];
       byDoc.set(key, list);
     }
     list.push(hit);
+  }
+
+  if (skippedHits > 0) {
+    const sample =
+      sampleIdsForWarn.length > 0 ? ` sample_ids=${sampleIdsForWarn.join(',')}` : '';
+    logWarn(
+      `reassembleByDocument: skipped ${skippedHits} hit(s) with no document key (document_number, url, doc_id, or non-empty vector id).${sample}`
+    );
   }
 
   const out: ReassembledDocument[] = [];


### PR DESCRIPTION
# Pull Request

## Reassemble skip signal

- src/server/reassemble-documents.ts: Count hits whose document key is empty; after the grouping loop, if skippedHits > 0, call warn once with total count and up to 3 sample vector ids (<empty> when id is blank). Message explains missing document_number, url, doc_id, or non-empty vector id.
- src/server/reassemble-documents.test.ts: vi.spyOn on ../logger.js warn in beforeEach/afterEach; tests for no warn when all keys valid, single skip, two skips one warn, mixed valid/invalid, and sample-id cap (using document_number: '' so keys stay empty while ids differ).
## Deprecation WARN latch
src/server/format-query-result.ts: Deprecation warn runs on the first formatSearchResultAsRow call in the process (still once per session via the latch), not only when document_id !== null. QueryResultRow.paper_number JSDoc updated to match.
- New src/server/format-query-result.test.ts: Reset latch + mock warn; asserts warn on first row with document_id null, no second warn, and a single warn for formatQueryResultRows with two hits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecation warning for paper number now logs exactly once per session
  * Added a single aggregated warning when search hits lack document keys, including a sampled list of hit IDs

* **Tests**
  * Added tests verifying deprecation warning behavior across calls
  * Added tests validating aggregated skip warnings and sampled ID reporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/pinecone-read-only-mcp-typescript/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->