### PR TITLE
Completes the context-complete tool path

### DIFF
--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -19,7 +19,7 @@ export async function setupAllianceServer(config?: ServerConfig): Promise<McpSer
     instructions: ALLIANCE_SERVER_INSTRUCTIONS,
   });
   const ctx = getDefaultServerContext();
-  registerBuiltinUrlGenerators();
+  registerBuiltinUrlGenerators(ctx);
   registerSuggestQueryParamsTool(server, ctx);
   registerGuidedQueryTool(server, ctx);
   return server;

--- a/src/alliance/tools/guided-query-tool.context.test.ts
+++ b/src/alliance/tools/guided-query-tool.context.test.ts
@@ -22,9 +22,9 @@ const namespaceMetadata = {
 
 function papersNamespaceClient(overrides?: { query?: ReturnType<typeof vi.fn> }) {
   return {
-    listNamespacesWithMetadata: vi.fn().mockResolvedValue([
-      { namespace: 'papers', recordCount: 42, metadata: namespaceMetadata },
-    ]),
+    listNamespacesWithMetadata: vi
+      .fn()
+      .mockResolvedValue([{ namespace: 'papers', recordCount: 42, metadata: namespaceMetadata }]),
     query: overrides?.query ?? vi.fn().mockResolvedValue(makeHybridQueryResult()),
     count: vi.fn().mockResolvedValue({ count: 7, truncated: false }),
   };
@@ -105,8 +105,7 @@ describe('guided_query tool handler (ServerContext instance path)', () => {
   });
 
   it('enriches urls via ctx builtins when enrich_urls is true', async () => {
-    const mailingDocId =
-      'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
+    const mailingDocId = 'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
     const query = vi.fn().mockResolvedValue(
       makeHybridQueryResult({
         results: [
@@ -156,9 +155,9 @@ describe('guided_query tool handler (ServerContext instance path)', () => {
   });
 
   it('returns TIMEOUT when orchestrator client throws timeout error', async () => {
-    const query = vi.fn().mockRejectedValue(
-      new Error('Timeout after 5000ms while waiting for query')
-    );
+    const query = vi
+      .fn()
+      .mockRejectedValue(new Error('Timeout after 5000ms while waiting for query'));
     const ctx = createTestServerContext({
       client: papersNamespaceClient({ query }) as never,
     });

--- a/src/alliance/tools/guided-query-tool.context.test.ts
+++ b/src/alliance/tools/guided-query-tool.context.test.ts
@@ -1,11 +1,34 @@
 import { describe, expect, it, vi } from 'vitest';
+import { registerBuiltinUrlGenerators } from '../url-builtins.js';
+import { registerQueryTool } from '../../core/server/tools/query-tool.js';
+import { registerSuggestQueryParamsTool } from './suggest-query-params-tool.js';
 import { registerGuidedQueryTool } from './guided-query-tool.js';
 import {
+  assertToolErrorCode,
   createMockServer,
   createTestServerContext,
   makeHybridQueryResult,
+  makeSearchResult,
   parseToolJson,
 } from '../../core/server/tools/test-helpers.js';
+
+const namespaceMetadata = {
+  document_number: 'string',
+  title: 'string',
+  url: 'string',
+  author: 'string',
+  chunk_text: 'string',
+};
+
+function papersNamespaceClient(overrides?: { query?: ReturnType<typeof vi.fn> }) {
+  return {
+    listNamespacesWithMetadata: vi.fn().mockResolvedValue([
+      { namespace: 'papers', recordCount: 42, metadata: namespaceMetadata },
+    ]),
+    query: overrides?.query ?? vi.fn().mockResolvedValue(makeHybridQueryResult()),
+    count: vi.fn().mockResolvedValue({ count: 7, truncated: false }),
+  };
+}
 
 describe('guided_query tool handler (ServerContext instance path)', () => {
   it('returns success with decision_trace using injected context', async () => {
@@ -52,5 +75,139 @@ describe('guided_query tool handler (ServerContext instance path)', () => {
     });
     expect(trace['rerank_status']).toBeDefined();
     expect(query).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces degraded and hybrid_leg_failed in result', async () => {
+    const query = vi.fn().mockResolvedValue(
+      makeHybridQueryResult({
+        degraded: true,
+        degradation_reason: 'sparse_leg_empty',
+        hybrid_leg_failed: 'sparse',
+      })
+    );
+    const ctx = createTestServerContext({
+      client: papersNamespaceClient({ query }) as never,
+    });
+    const server = createMockServer();
+    registerGuidedQueryTool(server as never, ctx);
+    const body = parseToolJson(
+      await server.getHandler('guided_query')!({
+        user_query: 'contracts',
+        namespace: 'papers',
+        preferred_tool: 'fast',
+        enrich_urls: false,
+      })
+    );
+    const result = body['result'] as Record<string, unknown>;
+    expect(result['degraded']).toBe(true);
+    expect(result['hybrid_leg_failed']).toBe('sparse');
+    expect(result['degradation_reason']).toBe('sparse_leg_empty');
+  });
+
+  it('enriches urls via ctx builtins when enrich_urls is true', async () => {
+    const mailingDocId =
+      'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
+    const query = vi.fn().mockResolvedValue(
+      makeHybridQueryResult({
+        results: [
+          makeSearchResult({
+            metadata: {
+              document_number: 'MSG-1',
+              title: 'T',
+              author: 'A',
+              doc_id: mailingDocId,
+            },
+          }),
+        ],
+      })
+    );
+    const ctx = createTestServerContext({
+      client: {
+        listNamespacesWithMetadata: vi.fn().mockResolvedValue([
+          {
+            namespace: 'mailing',
+            recordCount: 42,
+            metadata: {
+              document_number: 'string',
+              title: 'string',
+              author: 'string',
+              chunk_text: 'string',
+            },
+          },
+        ]),
+        query,
+        count: vi.fn(),
+      } as never,
+    });
+    registerBuiltinUrlGenerators(ctx);
+    const server = createMockServer();
+    registerGuidedQueryTool(server as never, ctx);
+    const body = parseToolJson(
+      await server.getHandler('guided_query')!({
+        user_query: 'announcement',
+        namespace: 'mailing',
+        preferred_tool: 'fast',
+        enrich_urls: true,
+      })
+    );
+    const result = body['result'] as Record<string, unknown>;
+    const rows = result['results'] as Array<{ url: string }>;
+    expect(rows[0]?.url).toContain('lists.boost.org');
+  });
+
+  it('returns TIMEOUT when orchestrator client throws timeout error', async () => {
+    const query = vi.fn().mockRejectedValue(
+      new Error('Timeout after 5000ms while waiting for query')
+    );
+    const ctx = createTestServerContext({
+      client: papersNamespaceClient({ query }) as never,
+    });
+    const server = createMockServer();
+    registerGuidedQueryTool(server as never, ctx);
+    const err = assertToolErrorCode(
+      await server.getHandler('guided_query')!({
+        user_query: 'contracts',
+        namespace: 'papers',
+        preferred_tool: 'fast',
+        enrich_urls: false,
+      }),
+      'TIMEOUT'
+    );
+    expect(err.suggestion).toMatch(/retry|timeout/i);
+  });
+
+  it('does not block explicit suggest_query_params after internal suggest', async () => {
+    const ctx = createTestServerContext({
+      client: papersNamespaceClient() as never,
+    });
+    const guidedServer = createMockServer();
+    registerGuidedQueryTool(guidedServer as never, ctx);
+    await guidedServer.getHandler('guided_query')!({
+      user_query: 'What does the paper say?',
+      namespace: 'papers',
+      preferred_tool: 'fast',
+      enrich_urls: false,
+    });
+
+    const suggestServer = createMockServer();
+    registerSuggestQueryParamsTool(suggestServer as never, ctx);
+    const suggestBody = parseToolJson(
+      await suggestServer.getHandler('suggest_query_params')!({
+        namespace: 'papers',
+        user_query: 'List titles',
+      })
+    );
+    expect(suggestBody['status']).toBe('success');
+
+    const queryServer = createMockServer();
+    registerQueryTool(queryServer as never, ctx);
+    const queryBody = parseToolJson(
+      await queryServer.getHandler('query')!({
+        query_text: 'List titles',
+        namespace: 'papers',
+        preset: 'fast',
+      })
+    );
+    expect(queryBody['status']).toBe('success');
   });
 });

--- a/src/alliance/tools/guided-query-tool.ts
+++ b/src/alliance/tools/guided-query-tool.ts
@@ -229,6 +229,7 @@ export function registerGuidedQueryTool(server: McpServer, ctx?: ServerContext):
         const formattedResults = formatQueryResultRows(queryOutcome.results, {
           namespace,
           enrichUrls: enrich_urls,
+          ctx,
         });
         const result: QueryResponse = {
           status: 'success',

--- a/src/alliance/tools/isolated-context.context.test.ts
+++ b/src/alliance/tools/isolated-context.context.test.ts
@@ -9,10 +9,12 @@ import {
   makeSearchResult,
   parseToolJson,
 } from '../../core/server/tools/test-helpers.js';
-import { getDefaultServerContext, teardownDefaultServerContext } from '../../core/server/server-context.js';
+import {
+  getDefaultServerContext,
+  teardownDefaultServerContext,
+} from '../../core/server/server-context.js';
 
-const MAILING_DOC_ID =
-  'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
+const MAILING_DOC_ID = 'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
 const EXPECTED_MAILING_URL = `https://lists.boost.org/archives/list/${MAILING_DOC_ID}/`;
 
 describe('isolated ServerContext with zero default context', () => {

--- a/src/alliance/tools/isolated-context.context.test.ts
+++ b/src/alliance/tools/isolated-context.context.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerBuiltinUrlGenerators } from '../url-builtins.js';
+import { registerGuidedQueryTool } from './guided-query-tool.js';
+import {
+  createMockServer,
+  createTestServerContext,
+  isolateFromDefaultContext,
+  makeHybridQueryResult,
+  makeSearchResult,
+  parseToolJson,
+} from '../../core/server/tools/test-helpers.js';
+import { getDefaultServerContext, teardownDefaultServerContext } from '../../core/server/server-context.js';
+
+const MAILING_DOC_ID =
+  'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
+const EXPECTED_MAILING_URL = `https://lists.boost.org/archives/list/${MAILING_DOC_ID}/`;
+
+describe('isolated ServerContext with zero default context', () => {
+  beforeEach(() => {
+    isolateFromDefaultContext();
+  });
+
+  afterEach(() => {
+    teardownDefaultServerContext();
+  });
+
+  it('guided_query enrich_urls uses ctx builtins, not default registry', async () => {
+    const listNamespacesWithMetadata = vi.fn().mockResolvedValue([
+      {
+        namespace: 'mailing',
+        recordCount: 42,
+        metadata: {
+          document_number: 'string',
+          title: 'string',
+          author: 'string',
+          chunk_text: 'string',
+        },
+      },
+    ]);
+    const query = vi.fn().mockResolvedValue(
+      makeHybridQueryResult({
+        results: [
+          makeSearchResult({
+            metadata: {
+              document_number: 'MSG-1',
+              title: 'T',
+              author: 'A',
+              doc_id: MAILING_DOC_ID,
+            },
+          }),
+        ],
+      })
+    );
+    const ctx = createTestServerContext({
+      client: {
+        listNamespacesWithMetadata,
+        query,
+        count: vi.fn(),
+      } as never,
+    });
+    registerBuiltinUrlGenerators(ctx);
+
+    const server = createMockServer();
+    registerGuidedQueryTool(server as never, ctx);
+    const raw = await server.getHandler('guided_query')!({
+      user_query: 'What was announced?',
+      namespace: 'mailing',
+      preferred_tool: 'fast',
+      enrich_urls: true,
+    });
+    const body = parseToolJson(raw);
+    const result = body['result'] as Record<string, unknown>;
+    const rows = result['results'] as Array<{ url: string }>;
+    expect(rows[0]?.url).toBe(EXPECTED_MAILING_URL);
+    expect(getDefaultServerContext().hasUrlGenerator('mailing')).toBe(false);
+  });
+});

--- a/src/alliance/tools/suggest-query-params-tool.context.test.ts
+++ b/src/alliance/tools/suggest-query-params-tool.context.test.ts
@@ -18,9 +18,9 @@ const namespaceMetadata = {
 
 function mockNamespacesClient() {
   return {
-    listNamespacesWithMetadata: vi.fn().mockResolvedValue([
-      { namespace: 'wg21', recordCount: 42, metadata: namespaceMetadata },
-    ]),
+    listNamespacesWithMetadata: vi
+      .fn()
+      .mockResolvedValue([{ namespace: 'wg21', recordCount: 42, metadata: namespaceMetadata }]),
   };
 }
 

--- a/src/alliance/tools/suggest-query-params-tool.context.test.ts
+++ b/src/alliance/tools/suggest-query-params-tool.context.test.ts
@@ -1,12 +1,34 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerQueryTool } from '../../core/server/tools/query-tool.js';
 import { registerSuggestQueryParamsTool } from './suggest-query-params-tool.js';
 import {
   createMockServer,
   createTestServerContext,
+  makeHybridQueryResult,
   parseToolJson,
 } from '../../core/server/tools/test-helpers.js';
 
+const namespaceMetadata = {
+  document_number: 'string',
+  title: 'string',
+  url: 'string',
+  author: 'string',
+  chunk_text: 'string',
+};
+
+function mockNamespacesClient() {
+  return {
+    listNamespacesWithMetadata: vi.fn().mockResolvedValue([
+      { namespace: 'wg21', recordCount: 42, metadata: namespaceMetadata },
+    ]),
+  };
+}
+
 describe('suggest_query_params tool handler (ServerContext instance path)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('marks suggest-flow on injected context when namespace exists', async () => {
     const listNamespacesWithMetadata = vi.fn().mockResolvedValue([
       {
@@ -40,5 +62,56 @@ describe('suggest_query_params tool handler (ServerContext instance path)', () =
 
     const flowCheck = ctx.requireSuggested('wg21');
     expect(flowCheck.ok).toBe(true);
+  });
+
+  it('updates suggestion state when called twice for the same namespace', async () => {
+    const ctx = createTestServerContext({
+      client: mockNamespacesClient() as never,
+    });
+    const server = createMockServer();
+    registerSuggestQueryParamsTool(server as never, ctx);
+    const handler = server.getHandler('suggest_query_params')!;
+
+    await handler({ namespace: 'wg21', user_query: 'List papers with titles' });
+    await handler({ namespace: 'wg21', user_query: 'how many records match?' });
+
+    const flowCheck = ctx.requireSuggested('wg21');
+    expect(flowCheck.ok).toBe(true);
+    if (flowCheck.ok) {
+      expect(flowCheck.flow.user_query).toBe('how many records match?');
+      expect(flowCheck.flow.recommended_tool).toBe('count');
+    }
+  });
+
+  it('re-suggest after expiry allows query without FLOW_GATE', async () => {
+    vi.useFakeTimers();
+    const query = vi.fn().mockResolvedValue(makeHybridQueryResult());
+    const ctx = createTestServerContext({
+      config: { cacheTtlSeconds: 1 },
+      client: { ...mockNamespacesClient(), query } as never,
+    });
+    const suggestServer = createMockServer();
+    registerSuggestQueryParamsTool(suggestServer as never, ctx);
+    const suggestHandler = suggestServer.getHandler('suggest_query_params')!;
+
+    await suggestHandler({ namespace: 'wg21', user_query: 'contracts' });
+    vi.advanceTimersByTime(2000);
+
+    const reSuggestBody = parseToolJson(
+      await suggestHandler({ namespace: 'wg21', user_query: 'contracts again' })
+    );
+    expect(reSuggestBody['status']).toBe('success');
+
+    const queryServer = createMockServer();
+    registerQueryTool(queryServer as never, ctx);
+    const queryBody = parseToolJson(
+      await queryServer.getHandler('query')!({
+        query_text: 'contracts again',
+        namespace: 'wg21',
+        preset: 'fast',
+      })
+    );
+    expect(queryBody['status']).toBe('success');
+    expect(query).toHaveBeenCalledOnce();
   });
 });

--- a/src/alliance/url-builtins.context.test.ts
+++ b/src/alliance/url-builtins.context.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { registerBuiltinUrlGenerators } from './url-builtins.js';
 import { createTestServerContext } from '../core/server/tools/test-helpers.js';
 
-const MAILING_DOC_ID =
-  'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
+const MAILING_DOC_ID = 'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
 
 describe('registerBuiltinUrlGenerators (ServerContext instance path)', () => {
   it('registers builtins only on the target context', () => {

--- a/src/alliance/url-builtins.context.test.ts
+++ b/src/alliance/url-builtins.context.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { registerBuiltinUrlGenerators } from './url-builtins.js';
+import { createTestServerContext } from '../core/server/tools/test-helpers.js';
+
+const MAILING_DOC_ID =
+  'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
+
+describe('registerBuiltinUrlGenerators (ServerContext instance path)', () => {
+  it('registers builtins only on the target context', () => {
+    const ctxA = createTestServerContext();
+    const ctxB = createTestServerContext();
+    registerBuiltinUrlGenerators(ctxA);
+
+    const metadata = { doc_id: MAILING_DOC_ID };
+    const fromA = ctxA.generateUrlForNamespace('mailing', metadata);
+    const fromB = ctxB.generateUrlForNamespace('mailing', metadata);
+
+    expect(fromA.url).toContain('lists.boost.org');
+    expect(fromA.method).toBe('generated.mailing');
+    expect(fromB.method).toBe('unavailable');
+    expect(fromB.url).toBeNull();
+  });
+});

--- a/src/alliance/url-builtins.ts
+++ b/src/alliance/url-builtins.ts
@@ -85,7 +85,8 @@ function isServerContext(value: unknown): value is ServerContext {
     typeof value === 'object' &&
     value !== null &&
     typeof (value as ServerContext).getConfig === 'function' &&
-    typeof (value as ServerContext).generateUrlForNamespace === 'function'
+    typeof (value as ServerContext).generateUrlForNamespace === 'function' &&
+    typeof (value as ServerContext).registerUrlGenerator === 'function'
   );
 }
 

--- a/src/alliance/url-builtins.ts
+++ b/src/alliance/url-builtins.ts
@@ -103,9 +103,7 @@ function registerBuiltinsOnDefaultContext(options?: RegisterBuiltinUrlGenerators
 }
 
 /** Register built-in Alliance generators on the process-default context (legacy). */
-export function registerBuiltinUrlGenerators(
-  options?: RegisterBuiltinUrlGeneratorsOptions
-): void;
+export function registerBuiltinUrlGenerators(options?: RegisterBuiltinUrlGeneratorsOptions): void;
 /** Register built-in Alliance generators on the given {@link ServerContext}. */
 export function registerBuiltinUrlGenerators(
   ctx: ServerContext,

--- a/src/alliance/url-builtins.ts
+++ b/src/alliance/url-builtins.ts
@@ -2,6 +2,7 @@
  * C++ Alliance domain-specific URL generators (Boost mailing list, Slack).
  */
 
+import type { ServerContext } from '../core/server/server-context.js';
 import { registerUrlGenerator } from '../core/server/url-registry.js';
 import type { UrlGenerationResult } from '../core/server/url-registry.js';
 
@@ -62,7 +63,8 @@ export function generatorSlackCpplang(metadata: Record<string, unknown>): UrlGen
   };
 }
 
-let builtinGeneratorsRegistered = false;
+const builtinGeneratorsRegisteredContexts = new WeakSet<ServerContext>();
+let defaultBuiltinGeneratorsRegistered = false;
 
 /** Options for {@link registerBuiltinUrlGenerators}. */
 export type RegisterBuiltinUrlGeneratorsOptions = {
@@ -73,18 +75,58 @@ export type RegisterBuiltinUrlGeneratorsOptions = {
   reinstallBuiltins?: boolean;
 };
 
-/**
- * Register built-in Alliance generators (`mailing`, `slack-Cpplang`).
- */
-export function registerBuiltinUrlGenerators(options?: RegisterBuiltinUrlGeneratorsOptions): void {
+function registerBuiltinsOnContext(ctx: ServerContext): void {
+  ctx.registerUrlGenerator('mailing', generatorMailing);
+  ctx.registerUrlGenerator('slack-Cpplang', generatorSlackCpplang);
+}
+
+function isServerContext(value: unknown): value is ServerContext {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as ServerContext).getConfig === 'function' &&
+    typeof (value as ServerContext).generateUrlForNamespace === 'function'
+  );
+}
+
+function registerBuiltinsOnDefaultContext(options?: RegisterBuiltinUrlGeneratorsOptions): void {
   if (options?.reinstallBuiltins) {
     registerUrlGenerator('mailing', generatorMailing);
     registerUrlGenerator('slack-Cpplang', generatorSlackCpplang);
-    builtinGeneratorsRegistered = true;
+    defaultBuiltinGeneratorsRegistered = true;
     return;
   }
-  if (builtinGeneratorsRegistered) return;
+  if (defaultBuiltinGeneratorsRegistered) return;
   registerUrlGenerator('mailing', generatorMailing);
   registerUrlGenerator('slack-Cpplang', generatorSlackCpplang);
-  builtinGeneratorsRegistered = true;
+  defaultBuiltinGeneratorsRegistered = true;
+}
+
+/** Register built-in Alliance generators on the process-default context (legacy). */
+export function registerBuiltinUrlGenerators(
+  options?: RegisterBuiltinUrlGeneratorsOptions
+): void;
+/** Register built-in Alliance generators on the given {@link ServerContext}. */
+export function registerBuiltinUrlGenerators(
+  ctx: ServerContext,
+  options?: RegisterBuiltinUrlGeneratorsOptions
+): void;
+export function registerBuiltinUrlGenerators(
+  ctxOrOptions?: ServerContext | RegisterBuiltinUrlGeneratorsOptions,
+  options?: RegisterBuiltinUrlGeneratorsOptions
+): void {
+  if (isServerContext(ctxOrOptions)) {
+    const ctx = ctxOrOptions;
+    if (options?.reinstallBuiltins) {
+      registerBuiltinsOnContext(ctx);
+      builtinGeneratorsRegisteredContexts.add(ctx);
+      return;
+    }
+    if (builtinGeneratorsRegisteredContexts.has(ctx)) return;
+    registerBuiltinsOnContext(ctx);
+    builtinGeneratorsRegisteredContexts.add(ctx);
+    return;
+  }
+
+  registerBuiltinsOnDefaultContext(ctxOrOptions);
 }

--- a/src/core/server/format-query-result.context.test.ts
+++ b/src/core/server/format-query-result.context.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { formatSearchResultAsRow } from './format-query-result.js';
+import { ServerContext } from './server-context.js';
+import { isolateFromDefaultContext, resolveTestConfig } from './tools/test-helpers.js';
+import { teardownDefaultServerContext } from './server-context.js';
+import type { SearchResult } from '../../types.js';
+
+describe('formatSearchResultAsRow (ServerContext instance path)', () => {
+  afterEach(() => {
+    teardownDefaultServerContext();
+  });
+
+  it('enriches url from injected ctx registry when default context has no generator', () => {
+    isolateFromDefaultContext();
+    const ctx = new ServerContext(resolveTestConfig());
+    ctx.registerUrlGenerator('papers', () => ({
+      url: 'https://ctx.example/papers/doc-1',
+      method: 'generated.custom',
+    }));
+
+    const doc: SearchResult = {
+      id: 'v1',
+      content: 'body',
+      score: 0.9,
+      metadata: { document_number: 'DOC-1', title: 'T', author: 'A' },
+      reranked: false,
+    };
+
+    const row = formatSearchResultAsRow(doc, {
+      namespace: 'papers',
+      enrichUrls: true,
+      ctx,
+    });
+    expect(row.url).toBe('https://ctx.example/papers/doc-1');
+  });
+});

--- a/src/core/server/format-query-result.ts
+++ b/src/core/server/format-query-result.ts
@@ -5,7 +5,15 @@
 
 import type { PineconeMetadataValue, SearchResult } from '../../types.js';
 import { warn as logWarn } from '../../logger.js';
+import type { ServerContext } from './server-context.js';
 import { generateUrlForNamespace } from './url-registry.js';
+
+export type FormatQueryResultOptions = {
+  namespace?: string;
+  enrichUrls?: boolean;
+  contentMaxLength?: number;
+  ctx?: ServerContext;
+};
 
 const DEFAULT_CONTENT_MAX_LENGTH = 2000;
 
@@ -53,17 +61,15 @@ export function resetPaperNumberDeprecationLatchForTests(): void {
  */
 export function formatSearchResultAsRow(
   doc: SearchResult,
-  options?: {
-    namespace?: string;
-    enrichUrls?: boolean;
-    contentMaxLength?: number;
-  }
+  options?: FormatQueryResultOptions
 ): QueryResultRow {
   const contentMaxLength = options?.contentMaxLength ?? DEFAULT_CONTENT_MAX_LENGTH;
   const metadata = { ...doc.metadata } as Record<string, PineconeMetadataValue>;
 
   if (options?.enrichUrls && options?.namespace) {
-    const generated = generateUrlForNamespace(options.namespace, metadata);
+    const generated = options.ctx
+      ? options.ctx.generateUrlForNamespace(options.namespace, metadata)
+      : generateUrlForNamespace(options.namespace, metadata);
     const existingUrl = metadata['url'];
     const urlIsBlank = typeof existingUrl !== 'string' || existingUrl.trim() === '';
     if (generated.url && urlIsBlank) {
@@ -105,11 +111,7 @@ export function formatSearchResultAsRow(
  */
 export function formatQueryResultRows(
   results: SearchResult[],
-  options?: {
-    namespace?: string;
-    enrichUrls?: boolean;
-    contentMaxLength?: number;
-  }
+  options?: FormatQueryResultOptions
 ): QueryResultRow[] {
   return results.map((doc) => formatSearchResultAsRow(doc, options));
 }

--- a/src/core/server/server-context.test.ts
+++ b/src/core/server/server-context.test.ts
@@ -5,7 +5,6 @@ import {
   ServerContext,
   createServer,
   getDefaultServerContext,
-  setDefaultServerContext,
   teardownDefaultServerContext,
 } from './server-context.js';
 
@@ -143,7 +142,6 @@ describe('ServerContext', () => {
   it('teardownDefaultServerContext clears process default', () => {
     createServer(testConfig());
     teardownDefaultServerContext();
-    setDefaultServerContext(null);
     const fresh = getDefaultServerContext();
     expect(fresh).not.toBeNull();
   });

--- a/src/core/server/server-context.test.ts
+++ b/src/core/server/server-context.test.ts
@@ -12,6 +12,7 @@ import {
 describe('ServerContext', () => {
   afterEach(() => {
     teardownDefaultServerContext();
+    vi.useRealTimers();
   });
 
   const testConfig = () => resolveTestConfig();
@@ -162,6 +163,5 @@ describe('ServerContext', () => {
     if (!expired.ok) {
       expect(expired.message).toMatch(/expired/);
     }
-    vi.useRealTimers();
   });
 });

--- a/src/core/server/server-context.test.ts
+++ b/src/core/server/server-context.test.ts
@@ -146,4 +146,22 @@ describe('ServerContext', () => {
     const fresh = getDefaultServerContext();
     expect(fresh).not.toBeNull();
   });
+
+  it('requireSuggested returns expiry message after TTL on instance context', () => {
+    vi.useFakeTimers();
+    const ctx = new ServerContext(resolveTestConfig({ cacheTtlSeconds: 1 }));
+    ctx.markSuggested('wg21', {
+      recommended_tool: 'fast',
+      suggested_fields: ['title'],
+      user_query: 'contracts',
+    });
+    expect(ctx.requireSuggested('wg21').ok).toBe(true);
+    vi.advanceTimersByTime(2000);
+    const expired = ctx.requireSuggested('wg21');
+    expect(expired.ok).toBe(false);
+    if (!expired.ok) {
+      expect(expired.message).toMatch(/expired/);
+    }
+    vi.useRealTimers();
+  });
 });

--- a/src/core/server/suggestion-flow.test.ts
+++ b/src/core/server/suggestion-flow.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  markSuggested,
-  requireSuggested,
-  resetSuggestionFlow,
-} from './suggestion-flow.js';
+import { markSuggested, requireSuggested, resetSuggestionFlow } from './suggestion-flow.js';
 import { createServer, teardownDefaultServerContext } from './server-context.js';
 import { resolveTestConfig } from './tools/test-helpers.js';
 

--- a/src/core/server/suggestion-flow.test.ts
+++ b/src/core/server/suggestion-flow.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  markSuggested,
+  requireSuggested,
+  resetSuggestionFlow,
+} from './suggestion-flow.js';
+import { createServer, teardownDefaultServerContext } from './server-context.js';
+import { resolveTestConfig } from './tools/test-helpers.js';
+
+describe('suggestion-flow facade (default ServerContext)', () => {
+  beforeEach(() => {
+    teardownDefaultServerContext();
+    createServer(resolveTestConfig({ disableSuggestFlow: false, cacheTtlSeconds: 1 }));
+  });
+
+  afterEach(() => {
+    teardownDefaultServerContext();
+    vi.useRealTimers();
+  });
+
+  it('markSuggested then requireSuggested succeeds', () => {
+    markSuggested('wg21', {
+      recommended_tool: 'fast',
+      suggested_fields: ['title'],
+      user_query: 'contracts',
+    });
+    const check = requireSuggested('wg21');
+    expect(check.ok).toBe(true);
+    if (check.ok) {
+      expect(check.flow.user_query).toBe('contracts');
+      expect(check.flow.recommended_tool).toBe('fast');
+    }
+  });
+
+  it('requireSuggested fails when namespace was never suggested', () => {
+    const check = requireSuggested('wg21');
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.message).toMatch(/suggest_query_params first/);
+    }
+  });
+
+  it('requireSuggested fails after TTL expiry', () => {
+    vi.useFakeTimers();
+    markSuggested('wg21', {
+      recommended_tool: 'detailed',
+      suggested_fields: ['chunk_text'],
+      user_query: 'q',
+    });
+    vi.advanceTimersByTime(2000);
+    const check = requireSuggested('wg21');
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.message).toMatch(/expired/);
+    }
+  });
+
+  it('requireSuggested bypasses gate when disableSuggestFlow is true', () => {
+    teardownDefaultServerContext();
+    createServer(resolveTestConfig({ disableSuggestFlow: true, cacheTtlSeconds: 1 }));
+    const check = requireSuggested('wg21');
+    expect(check.ok).toBe(true);
+  });
+
+  it('resetSuggestionFlow clears prior suggestion state', () => {
+    markSuggested('wg21', {
+      recommended_tool: 'count',
+      suggested_fields: [],
+      user_query: 'how many',
+    });
+    expect(requireSuggested('wg21').ok).toBe(true);
+    resetSuggestionFlow();
+    expect(requireSuggested('wg21').ok).toBe(false);
+  });
+});

--- a/src/core/server/tools/count-tool.context.test.ts
+++ b/src/core/server/tools/count-tool.context.test.ts
@@ -48,4 +48,22 @@ describe('count tool handler (ServerContext instance path)', () => {
     const err = assertToolErrorCode(raw, 'FLOW_GATE');
     expect(err.suggestion).toBe("Call suggest_query_params for namespace 'wg21' first");
   });
+
+  it('succeeds without prior suggest when disableSuggestFlow is true', async () => {
+    const count = vi.fn().mockResolvedValue({ count: 2, truncated: false });
+    const ctx = createTestServerContext({
+      config: { disableSuggestFlow: true },
+      client: { count } as never,
+    });
+    const server = createMockServer();
+    registerCountTool(server as never, ctx);
+    const body = parseToolJson(
+      await server.getHandler('count')!({
+        namespace: 'wg21',
+        query_text: 'how many',
+      })
+    );
+    expect(body['status']).toBe('success');
+    expect(count).toHaveBeenCalledOnce();
+  });
 });

--- a/src/core/server/tools/keyword-search-tool.ts
+++ b/src/core/server/tools/keyword-search-tool.ts
@@ -87,6 +87,7 @@ async function executeKeywordSearch(
 
   const formattedResults = formatQueryResultRows(results, {
     namespace: normalizedNamespace,
+    ctx,
   });
 
   const response: KeywordSearchResponse = {

--- a/src/core/server/tools/query-tool.context.test.ts
+++ b/src/core/server/tools/query-tool.context.test.ts
@@ -113,9 +113,7 @@ describe('query tool handler (ServerContext instance path)', () => {
     registerQueryTool(server as never, ctx);
     const handler = server.getHandler('query')!;
 
-    query.mockResolvedValue(
-      makeHybridQueryResult({ hybrid_leg_failed: 'dense', degraded: false })
-    );
+    query.mockResolvedValue(makeHybridQueryResult({ hybrid_leg_failed: 'dense', degraded: false }));
     const denseBody = parseToolJson(
       await handler({ query_text: 'a', namespace: 'wg21', preset: 'fast' })
     );
@@ -131,9 +129,9 @@ describe('query tool handler (ServerContext instance path)', () => {
   });
 
   it('returns TIMEOUT when client throws timeout error', async () => {
-    const query = vi.fn().mockRejectedValue(
-      new Error('Timeout after 5000ms while waiting for query')
-    );
+    const query = vi
+      .fn()
+      .mockRejectedValue(new Error('Timeout after 5000ms while waiting for query'));
     const ctx = createTestServerContext({
       client: { query } as never,
     });

--- a/src/core/server/tools/query-tool.context.test.ts
+++ b/src/core/server/tools/query-tool.context.test.ts
@@ -51,4 +51,107 @@ describe('query tool handler (ServerContext instance path)', () => {
     const err = assertToolErrorCode(raw, 'FLOW_GATE');
     expect(err.suggestion).toBe("Call suggest_query_params for namespace 'wg21' first");
   });
+
+  it('succeeds without prior suggest when disableSuggestFlow is true', async () => {
+    const query = vi.fn().mockResolvedValue(makeHybridQueryResult());
+    const ctx = createTestServerContext({
+      config: { disableSuggestFlow: true },
+      client: { query } as never,
+    });
+    const server = createMockServer();
+    registerQueryTool(server as never, ctx);
+    const body = parseToolJson(
+      await server.getHandler('query')!({
+        query_text: 'hello',
+        namespace: 'wg21',
+        preset: 'fast',
+      })
+    );
+    expect(body['status']).toBe('success');
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  it('forwards rerank_skipped_reason and degradation_reason on injected context', async () => {
+    const query = vi.fn().mockResolvedValue(
+      makeHybridQueryResult({
+        rerank_skipped_reason: 'no_model',
+        degradation_reason: 'rerank_skipped_no_model: set PINECONE_RERANK_MODEL',
+      })
+    );
+    const ctx = createTestServerContext({
+      client: { query } as never,
+    });
+    ctx.markSuggested('wg21', {
+      recommended_tool: 'detailed',
+      suggested_fields: ['chunk_text'],
+      user_query: 'q',
+    });
+    const server = createMockServer();
+    registerQueryTool(server as never, ctx);
+    const body = parseToolJson(
+      await server.getHandler('query')!({
+        query_text: 'hello',
+        namespace: 'wg21',
+        preset: 'detailed',
+      })
+    );
+    expect(body['rerank_skipped_reason']).toBe('no_model');
+    expect(body['degradation_reason']).toMatch(/rerank_skipped_no_model/);
+  });
+
+  it('forwards hybrid_leg_failed for dense and sparse partial hybrid', async () => {
+    const query = vi.fn();
+    const ctx = createTestServerContext({
+      client: { query } as never,
+    });
+    ctx.markSuggested('wg21', {
+      recommended_tool: 'fast',
+      suggested_fields: ['title'],
+      user_query: 'q',
+    });
+    const server = createMockServer();
+    registerQueryTool(server as never, ctx);
+    const handler = server.getHandler('query')!;
+
+    query.mockResolvedValue(
+      makeHybridQueryResult({ hybrid_leg_failed: 'dense', degraded: false })
+    );
+    const denseBody = parseToolJson(
+      await handler({ query_text: 'a', namespace: 'wg21', preset: 'fast' })
+    );
+    expect(denseBody['hybrid_leg_failed']).toBe('dense');
+
+    query.mockResolvedValue(
+      makeHybridQueryResult({ hybrid_leg_failed: 'sparse', degraded: false })
+    );
+    const sparseBody = parseToolJson(
+      await handler({ query_text: 'b', namespace: 'wg21', preset: 'fast' })
+    );
+    expect(sparseBody['hybrid_leg_failed']).toBe('sparse');
+  });
+
+  it('returns TIMEOUT when client throws timeout error', async () => {
+    const query = vi.fn().mockRejectedValue(
+      new Error('Timeout after 5000ms while waiting for query')
+    );
+    const ctx = createTestServerContext({
+      client: { query } as never,
+    });
+    ctx.markSuggested('wg21', {
+      recommended_tool: 'fast',
+      suggested_fields: ['title'],
+      user_query: 'q',
+    });
+    const server = createMockServer();
+    registerQueryTool(server as never, ctx);
+    const err = assertToolErrorCode(
+      await server.getHandler('query')!({
+        query_text: 'hello',
+        namespace: 'wg21',
+        preset: 'fast',
+      }),
+      'TIMEOUT'
+    );
+    expect(err.suggestion).toMatch(/retry|timeout/i);
+  });
 });

--- a/src/core/server/tools/query-tool.ts
+++ b/src/core/server/tools/query-tool.ts
@@ -69,7 +69,7 @@ async function executeQuery(params: QueryExecParams, ctx?: ServerContext) {
       fields: fields?.length ? fields : undefined,
     });
 
-    const formattedResults = formatQueryResultRows(queryOutcome.results);
+    const formattedResults = formatQueryResultRows(queryOutcome.results, { ctx });
 
     const response: QueryResponse = {
       status: 'success',

--- a/src/core/server/tools/test-helpers.ts
+++ b/src/core/server/tools/test-helpers.ts
@@ -2,11 +2,7 @@ import type { HybridQueryResult, SearchResult } from '../../../types.js';
 import { resolveConfig } from '../../config.js';
 import type { PineconeClient } from '../../pinecone-client.js';
 import type { ConfigOverrides, ServerConfig } from '../../config.js';
-import {
-  ServerContext,
-  setDefaultServerContext,
-  teardownDefaultServerContext,
-} from '../server-context.js';
+import { ServerContext, teardownDefaultServerContext } from '../server-context.js';
 import type { ToolError, ToolErrorCode } from '../tool-error.js';
 import { toolErrorSchema } from '../tool-error.js';
 
@@ -134,7 +130,6 @@ export function resolveTestConfig(overrides: ConfigOverrides = {}): ServerConfig
 /** Clear process-default context so tests exercise an isolated instance only. */
 export function isolateFromDefaultContext(): void {
   teardownDefaultServerContext();
-  setDefaultServerContext(null);
 }
 
 /** Build an isolated {@link ServerContext} for instance-path tool tests. */

--- a/src/core/server/tools/test-helpers.ts
+++ b/src/core/server/tools/test-helpers.ts
@@ -2,7 +2,11 @@ import type { HybridQueryResult, SearchResult } from '../../../types.js';
 import { resolveConfig } from '../../config.js';
 import type { PineconeClient } from '../../pinecone-client.js';
 import type { ConfigOverrides, ServerConfig } from '../../config.js';
-import { ServerContext } from '../server-context.js';
+import {
+  ServerContext,
+  setDefaultServerContext,
+  teardownDefaultServerContext,
+} from '../server-context.js';
 import type { ToolError, ToolErrorCode } from '../tool-error.js';
 import { toolErrorSchema } from '../tool-error.js';
 
@@ -125,6 +129,12 @@ export function resolveTestConfig(overrides: ConfigOverrides = {}): ServerConfig
     cacheTtlSeconds: TEST_CACHE_TTL_SECONDS,
     ...overrides,
   });
+}
+
+/** Clear process-default context so tests exercise an isolated instance only. */
+export function isolateFromDefaultContext(): void {
+  teardownDefaultServerContext();
+  setDefaultServerContext(null);
 }
 
 /** Build an isolated {@link ServerContext} for instance-path tool tests. */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       thresholds: {
         lines: 73,
         statements: 72,
-        branches: 58,
+        branches: 65,
         functions: 76,
       },
     },


### PR DESCRIPTION
# PR body (paste below the title on GitHub)

- Close #120
- Close #133
- Close #138

## Summary

Phase 3 completes the context-complete tool path: formatters and Alliance URL builtins use the injected `ServerContext` on the instance path, and new `.context.test.ts` / `suggestion-flow.test.ts` coverage exercises suggest-flow TTL, degradation, timeouts, and isolated-context URL enrichment without relying on process-default facades.

## Issues addressed

- **#120** — helper threading + instance-path safety net
- **#133** — format-query-result / guided-query / url-builtins context threading
- **#138** — suggest-flow mode-conditional branch testing

## Changes

- `formatSearchResultAsRow` / `formatQueryResultRows` accept optional `ctx` and call `ctx.generateUrlForNamespace()` when enriching URLs
- `query`, `keyword_search`, and `guided_query` pass `ctx` through to formatters
- `registerBuiltinUrlGenerators(ctx?, options?)` registers per-context via `WeakSet`; `setupAllianceServer` passes the same `ctx` as tool registration
- Overloads preserve legacy `registerBuiltinUrlGenerators({ reinstallBuiltins: true })` call sites
- `isolateFromDefaultContext()` test helper for phase 3 exit criterion
- Branch coverage threshold raised from 58% to 65%

## Acceptance criteria

### #120

- [x] Formatter accepts `ctx`; tools pass `ctx` to formatters
- [x] `registerBuiltinUrlGenerators(ctx?)` + `setupAllianceServer` wiring
- [x] `guided_query` instance path uses `ctx` for client, cache, suggest-flow, URL enrichment
- [x] No new `getDefaultServerContext()` imports outside facade modules
- [x] Isolated integration test, zero default context (`isolated-context.context.test.ts`)
- [x] Branch scenarios: TTL, cache (existing), hybrid dense/sparse, rerank-skipped, timeout
- [x] New tests use `createTestServerContext()` / `.context.test.ts`, no facade mocks
- [x] Branch coverage ≥ 65% (measured 74.64%)

### #138

- [x] Double `suggest_query_params` updates state, not duplicates
- [x] Re-suggest after expiry → `query` succeeds, no FLOW_GATE
- [x] `guided_query` does not block subsequent explicit `suggest_query_params`
- [x] Mode-conditional gating: `disableSuggestFlow` on `query` + `count` instance path
- [x] `suggestion-flow.ts` facade fully exercised (`suggestion-flow.test.ts`; file has no branch points in v8 report)

### #133

- [x] `format-query-result` uses context-owned URL registry when `ctx` provided
- [x] `guided-query` delegates to `ctx` suggest-flow / cache / client on instance path
- [x] URL builtins register on context registry, not global latch
- [x] Legacy `*.test.ts` unchanged and still pass

## Test plan

- [x] `npm test` — 207 tests pass
- [x] `npm run test:coverage` — branches 74.64% (gate 65%), `suggestion-flow.ts` 100% statements
- [x] `npm run build` — compiles cleanly
- [x] Phase 3 exit: `guided_query` + `enrich_urls` on isolated `ServerContext`, zero default context
- [ ] Spot-check legacy CLI / `setupAllianceServer` default-context path unchanged (manual)

## Notes for #133 reviewers

Dual-path facade imports in `guided-query-tool.ts` remain for the legacy no-`ctx` path. The instance path is fully context-driven. Legacy `*.test.ts` files still mock module facades by design; new `.context.test.ts` files cover the instance path without facade mocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query results can be enriched using a specific server context for more accurate URLs
  * Formatting and search tools now use request/server context when shaping results

* **Bug Fixes**
  * Degraded, hybrid-failure and degradation-reason fields now surface in query results
  * Improved timeout detection with clearer retry/timeout guidance

* **Tests**
  * Expanded test coverage for suggestion flow, URL generators, and query/tool handlers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->