### PR TITLE
test: credential redaction verification and metadata filter fuzz hard…

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,10 +10,17 @@
 `src/logger.ts` implements `redactApiKey` and recursive redaction for structured log data:
 
 - UUID-shaped tokens (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) → `***`
+- Modern Pinecone keys (`pcsk_…`) → `***`
 - Substrings after `apiKey` / `api_key` / similar patterns → masked
 - `Authorization: Bearer …` tokens → masked
 
 Logs go to **stderr**; use `PINECONE_READ_ONLY_MCP_LOG_FORMAT=json` for pipelines and ensure downstream sinks treat stderr as sensitive.
+
+## MCP response redaction
+
+Tool responses returned to MCP clients (and LLM consumers) are sanitized in `src/core/server/tool-response.ts` via `redactSensitiveFields()` before JSON serialization. Only known sensitive keys are masked (`message`, `suggestion`, `degradation_reason`); document metadata UUIDs and other non-sensitive fields are preserved.
+
+This covers tool error payloads, hybrid degradation reasons, and SDK error text surfaced in DEBUG log mode — not only stderr logs.
 
 ## Docker image
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -103,6 +128,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1200,7 +1226,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1250,7 +1275,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -1442,7 +1466,6 @@
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -1600,7 +1623,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2034,7 +2056,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2276,7 +2297,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2625,7 +2645,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
       "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3445,7 +3464,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3951,7 +3969,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -3998,7 +4015,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4072,7 +4088,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4151,7 +4166,6 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -4302,7 +4316,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.0.2",
         "eslint-config-prettier": "^10.1.8",
-        "fast-check": "^4.8.0",
         "prettier": "^3.5.3",
         "tsx": "^4.19.2",
         "typescript": "^6.0.3",
@@ -97,38 +96,35 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1086,40 +1082,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2353,29 +2315,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/fast-check": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
-      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=12.17.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3557,23 +3496,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.0.2",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.8.0",
         "prettier": "^3.5.3",
         "tsx": "^4.19.2",
         "typescript": "^6.0.3",
@@ -96,35 +97,38 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1082,6 +1086,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2315,6 +2353,29 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3496,6 +3557,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1060,6 +1060,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.0.2",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.8.0",
         "prettier": "^3.5.3",
         "tsx": "^4.19.2",
         "typescript": "^6.0.3",
@@ -93,29 +94,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1188,6 +1166,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1237,6 +1216,7 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -1428,6 +1408,7 @@
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -1585,6 +1566,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2018,6 +2000,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2259,6 +2242,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2313,6 +2297,29 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2584,6 +2591,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
       "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3403,6 +3411,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3496,6 +3505,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -3891,6 +3917,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -3937,6 +3964,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4010,6 +4038,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4088,6 +4117,7 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -4238,6 +4268,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.8.0",
     "prettier": "^3.5.3",
     "tsx": "^4.19.2",
     "typescript": "^6.0.3",

--- a/src/core/pinecone/rerank.ts
+++ b/src/core/pinecone/rerank.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Pinecone } from '@pinecone-database/pinecone';
-import { error as logError } from '../../logger.js';
+import { error as logError, redactApiKey } from '../../logger.js';
 import type { MergedHit, SearchResult } from '../../types.js';
 
 export type RerankOutcome = {
@@ -59,7 +59,7 @@ export async function rerankResults(
     return { results: reranked, degraded: false };
   } catch (error) {
     logError('Error reranking results', error);
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = redactApiKey(error instanceof Error ? error.message : String(error));
     return {
       results: results.slice(0, topN).map((result) => ({
         id: result._id || '',

--- a/src/core/server/metadata-filter.fuzz.test.ts
+++ b/src/core/server/metadata-filter.fuzz.test.ts
@@ -1,0 +1,116 @@
+import * as fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { MAX_FILTER_DEPTH, validateMetadataFilterDetailed } from './metadata-filter.js';
+
+const primitiveArb = fc.oneof(fc.string(), fc.integer(), fc.boolean());
+
+const validLeafArb: fc.Arbitrary<Record<string, unknown>> = fc
+  .record({
+    field: fc
+      .string({ minLength: 1 })
+      .filter((s) => !s.startsWith('$'))
+      .map((name) => name || 'f'),
+    op: fc.constantFrom('$eq', '$ne', '$gt', '$gte', '$lt', '$lte'),
+    value: primitiveArb,
+  })
+  .map(({ field, op, value }) => ({ [field]: { [op]: value } }));
+
+const { filter: validFilterArb } = fc.letrec<{ filter: fc.Arbitrary<Record<string, unknown>> }>(
+  (tie) => ({
+    filter: fc.oneof(
+      validLeafArb,
+      fc.array(tie('filter'), { minLength: 1, maxLength: 3 }).map((items) => ({ $and: items })),
+      fc.array(tie('filter'), { minLength: 1, maxLength: 3 }).map((items) => ({ $or: items }))
+    ),
+  })
+);
+
+function deepAnd(levels: number): Record<string, unknown> {
+  if (levels === 0) return { leaf: { $eq: 1 } };
+  return { $and: [deepAnd(levels - 1)] };
+}
+
+describe('validateMetadataFilterDetailed fuzz', () => {
+  it('never throws on arbitrary JSON-like input', () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), (value) => {
+        if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          expect(() =>
+            validateMetadataFilterDetailed(value as Record<string, unknown>)
+          ).not.toThrow();
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('returns structured errors for known malformed filters', () => {
+    const malformed = [
+      { year: { $regex: '^202' } },
+      { tags: { $in: [] } },
+      { tags: { $nin: [] } },
+      { $and: [] },
+      { $or: [] },
+      { tags: { $in: [1, {} as unknown as number] } },
+      { tags: { $and: 'not-array' } },
+      { x: deepAnd(MAX_FILTER_DEPTH + 1) },
+    ];
+
+    for (const filter of malformed) {
+      const result = validateMetadataFilterDetailed(filter);
+      expect(result).not.toBeNull();
+      expect(result!.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('accepts valid complex generated filters unchanged', () => {
+    fc.assert(
+      fc.property(validFilterArb, (filter) => {
+        const result = validateMetadataFilterDetailed(filter);
+        expect(result).toBeNull();
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('accepts hand-crafted deeply nested valid filters within depth limit', () => {
+    const valid = {
+      $and: [
+        { status: { $eq: 'published' } },
+        {
+          $or: [
+            { year: { $gte: 2020 } },
+            {
+              tags: {
+                $in: ['cpp', 'contracts'],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    expect(validateMetadataFilterDetailed(valid)).toBeNull();
+    expect(validateMetadataFilterDetailed({ x: deepAnd(MAX_FILTER_DEPTH) })).toBeNull();
+  });
+
+  it('handles special field names without throwing', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 0, maxLength: 20 }), primitiveArb, (fieldName, value) => {
+        const filter = { [fieldName]: { $eq: value } };
+        expect(() => validateMetadataFilterDetailed(filter)).not.toThrow();
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('rejects empty $in and accepts large primitive $in arrays', () => {
+    expect(validateMetadataFilterDetailed({ tags: { $in: [] } })!.field).toBe('tags.$in');
+
+    const largeIn = {
+      tags: { $in: Array.from({ length: 1000 }, (_, i) => (i % 3 === 0 ? i : `v${i}`)) },
+    };
+    expect(validateMetadataFilterDetailed(largeIn)).toBeNull();
+
+    expect(validateMetadataFilterDetailed({ tags: { $in: ['only'] } })).toBeNull();
+  });
+});

--- a/src/core/server/metadata-filter.test.ts
+++ b/src/core/server/metadata-filter.test.ts
@@ -50,4 +50,45 @@ describe('validateMetadataFilterDetailed', () => {
     });
     expect(d!.field).toBe('tags.$or.0');
   });
+
+  it('accepts filter at maximum nesting depth', () => {
+    expect(validateMetadataFilterDetailed({ x: deepAnd(10) })).toBeNull();
+  });
+
+  it('rejects filter exceeding maximum nesting depth', () => {
+    const d = validateMetadataFilterDetailed({ x: deepAnd(11) });
+    expect(d).not.toBeNull();
+    expect(d!.message).toContain('maximum depth');
+    expect(d!.field).toBe('');
+  });
+
+  it('rejects empty $and at top level', () => {
+    const d = validateMetadataFilterDetailed({ $and: [] });
+    expect(d!.field).toBe('$and');
+    expect(d!.message).toContain('at least one filter object');
+  });
+
+  it('rejects empty $or at top level', () => {
+    const d = validateMetadataFilterDetailed({ $or: [] });
+    expect(d!.field).toBe('$or');
+    expect(d!.message).toContain('at least one filter object');
+  });
+
+  it('rejects empty $in', () => {
+    const d = validateMetadataFilterDetailed({ tags: { $in: [] } });
+    expect(d!.field).toBe('tags.$in');
+    expect(d!.message).toContain('at least one value');
+  });
+
+  it('rejects empty $nin', () => {
+    const d = validateMetadataFilterDetailed({ tags: { $nin: [] } });
+    expect(d!.field).toBe('tags.$nin');
+    expect(d!.message).toContain('at least one value');
+  });
 });
+
+/** Build a filter nested `levels` deep via $and combinators. */
+function deepAnd(levels: number): Record<string, unknown> {
+  if (levels === 0) return { leaf: { $eq: 1 } };
+  return { $and: [deepAnd(levels - 1)] };
+}

--- a/src/core/server/metadata-filter.ts
+++ b/src/core/server/metadata-filter.ts
@@ -27,6 +27,9 @@ const ALLOWED_FILTER_OPERATORS = new Set([
   '$or',
 ]);
 
+/** Maximum nested filter-record depth ($and/$or combinator layers). Depth 10 passes; 11 rejects. */
+export const MAX_FILTER_DEPTH = 10;
+
 export type MetadataFilterValidationError = {
   message: string;
   /** Dot-path to the failing segment (metadata key and/or operator chain). */
@@ -42,6 +45,7 @@ function isPrimitiveFilterValue(value: unknown): boolean {
 function isPrimitiveArray(value: unknown): boolean {
   return (
     Array.isArray(value) &&
+    value.length > 0 &&
     value.every((item) => ['string', 'number', 'boolean'].includes(typeof item))
   );
 }
@@ -50,10 +54,16 @@ function err(message: string, path: string[]): MetadataFilterValidationError {
   return { message, field: path.join('.') };
 }
 
+function combinatorAt(path: string[]): string | undefined {
+  const op = path[path.length - 1];
+  return op === '$and' || op === '$or' ? op : undefined;
+}
+
 /** Recursively validate a filter value; returns an error or null if valid. */
 function validateMetadataFilterValue(
   value: unknown,
-  path: string[]
+  path: string[],
+  depth: number
 ): MetadataFilterValidationError | null {
   if (value === null || value === undefined) {
     return err(`Invalid null/undefined at "${path.join('.')}".`, path);
@@ -64,6 +74,13 @@ function validateMetadataFilterValue(
   }
 
   if (Array.isArray(value)) {
+    const combinator = combinatorAt(path);
+    if (combinator !== undefined && value.length === 0) {
+      return err(
+        `Operator "${combinator}" at "${path.join('.')}" must contain at least one filter object.`,
+        path
+      );
+    }
     for (let i = 0; i < value.length; i++) {
       const item = value[i];
       if (typeof item !== 'object' || item === null || Array.isArray(item)) {
@@ -72,7 +89,7 @@ function validateMetadataFilterValue(
           [...path, String(i)]
         );
       }
-      const nestedError = validateMetadataFilterRecord(item as Record<string, unknown>);
+      const nestedError = validateMetadataFilterRecord(item as Record<string, unknown>, depth + 1);
       if (nestedError) return nestedError;
     }
     return null;
@@ -95,11 +112,25 @@ function validateMetadataFilterValue(
         [...path, key]
       );
     }
-    if ((key === '$in' || key === '$nin') && !isPrimitiveArray(nestedValue)) {
-      return err(
-        `Operator "${key}" at "${path.join('.')}" must use an array of primitive values.`,
-        [...path, key]
-      );
+    if (key === '$in' || key === '$nin') {
+      if (!Array.isArray(nestedValue)) {
+        return err(
+          `Operator "${key}" at "${path.join('.')}" must use an array of primitive values.`,
+          [...path, key]
+        );
+      }
+      if (nestedValue.length === 0) {
+        return err(`Operator "${key}" at "${path.join('.')}" must contain at least one value.`, [
+          ...path,
+          key,
+        ]);
+      }
+      if (!isPrimitiveArray(nestedValue)) {
+        return err(
+          `Operator "${key}" at "${path.join('.')}" must use an array of primitive values.`,
+          [...path, key]
+        );
+      }
     }
     if (
       (key === '$eq' ||
@@ -121,8 +152,18 @@ function validateMetadataFilterValue(
         key,
       ]);
     }
+    if (
+      (key === '$and' || key === '$or') &&
+      Array.isArray(nestedValue) &&
+      nestedValue.length === 0
+    ) {
+      return err(
+        `Operator "${key}" at "${path.join('.')}" must contain at least one filter object.`,
+        [...path, key]
+      );
+    }
 
-    const nestedError = validateMetadataFilterValue(nestedValue, [...path, key]);
+    const nestedError = validateMetadataFilterValue(nestedValue, [...path, key], depth);
     if (nestedError) {
       return nestedError;
     }
@@ -132,10 +173,17 @@ function validateMetadataFilterValue(
 }
 
 function validateMetadataFilterRecord(
-  filter: Record<string, unknown>
+  filter: Record<string, unknown>,
+  depth = 0
 ): MetadataFilterValidationError | null {
+  if (depth > MAX_FILTER_DEPTH) {
+    return {
+      message: `Filter nesting exceeds maximum depth of ${MAX_FILTER_DEPTH}.`,
+      field: '',
+    };
+  }
   for (const [field, value] of Object.entries(filter)) {
-    const error = validateMetadataFilterValue(value, [field]);
+    const error = validateMetadataFilterValue(value, [field], depth);
     if (error) return error;
   }
   return null;

--- a/src/core/server/redaction.test.ts
+++ b/src/core/server/redaction.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPineconeClient } from './client-context.js';
+import { getNamespacesWithCache } from './namespaces-cache.js';
+import { registerGuidedQueryTool } from '../../alliance/tools/guided-query-tool.js';
+import { setLogLevel } from '../../logger.js';
+import { redactApiKey, redactSensitiveFields } from '../../logger.js';
+import { classifyToolCatchError, pineconeToolError } from './tool-error.js';
+import { jsonErrorResponse, jsonResponse } from './tool-response.js';
+import { registerQueryTool } from './tools/query-tool.js';
+import * as suggestionFlow from './suggestion-flow.js';
+import {
+  assertToolErrorCode,
+  createMockServer,
+  makeHybridQueryResult,
+  makeNamespaceCacheEntry,
+  makeSearchResult,
+  parseToolJson,
+} from './tools/test-helpers.js';
+
+vi.mock('./client-context.js', () => ({
+  getPineconeClient: vi.fn(),
+}));
+
+vi.mock('./namespaces-cache.js', () => ({
+  getNamespacesWithCache: vi.fn(),
+}));
+
+vi.mock('./suggestion-flow.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./suggestion-flow.js')>();
+  return {
+    ...actual,
+    markSuggested: vi.fn(),
+  };
+});
+
+const PCSK_KEY = 'pcsk_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const UUID_KEY = '12345678-1234-1234-1234-123456789abc';
+
+const flowOk = {
+  ok: true as const,
+  flow: {
+    updatedAt: Date.now(),
+    recommended_tool: 'detailed' as const,
+    suggested_fields: ['chunk_text'],
+    user_query: 'q',
+  },
+};
+
+const mockedGetClient = vi.mocked(getPineconeClient);
+const mockedGetNamespaces = vi.mocked(getNamespacesWithCache);
+
+describe('redactApiKey', () => {
+  it('redacts pcsk_ Pinecone API keys', () => {
+    expect(redactApiKey(`auth failed: ${PCSK_KEY}`)).not.toContain(PCSK_KEY);
+    expect(redactApiKey(`auth failed: ${PCSK_KEY}`)).toContain('***');
+  });
+
+  it('redacts UUID-shaped tokens', () => {
+    expect(redactApiKey(`key ${UUID_KEY}`)).not.toContain(UUID_KEY);
+  });
+
+  it('redacts api_key assignment patterns', () => {
+    expect(redactApiKey('api_key=secret-value-here')).toMatch(/api_key=\*\*\*/i);
+  });
+
+  it('redacts Authorization Bearer tokens', () => {
+    expect(redactApiKey('Authorization: Bearer my-secret-token')).toMatch(/Bearer \*\*\*/);
+  });
+});
+
+describe('redactSensitiveFields', () => {
+  it('redacts only allowlisted keys and preserves other strings', () => {
+    const input = {
+      message: `failed ${PCSK_KEY}`,
+      results: [{ metadata: { document_id: UUID_KEY } }],
+    };
+    const out = redactSensitiveFields(input) as typeof input;
+    expect(out.message).not.toContain(PCSK_KEY);
+    expect(out.results[0].metadata.document_id).toBe(UUID_KEY);
+  });
+});
+
+describe('MCP response redaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(suggestionFlow, 'requireSuggested').mockReturnValue(flowOk);
+    mockedGetClient.mockReturnValue({
+      query: vi.fn().mockResolvedValue(makeHybridQueryResult()),
+      count: vi.fn(),
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setLogLevel('INFO');
+  });
+
+  it('redacts tool error message and suggestion in jsonErrorResponse', () => {
+    const err = pineconeToolError(`PINECONE_ERROR with ${PCSK_KEY}`, {
+      suggestion: `retry with ${PCSK_KEY}`,
+    });
+    const text = jsonErrorResponse(err).content[0]!.text;
+    expect(text).not.toContain(PCSK_KEY);
+    expect(text).toContain('***');
+  });
+
+  it('redacts classifyToolCatchError output in DEBUG mode', () => {
+    setLogLevel('DEBUG');
+    const err = classifyToolCatchError(new Error(`SDK auth failed ${PCSK_KEY}`), 'fallback');
+    const text = jsonErrorResponse(err).content[0]!.text;
+    expect(text).not.toContain(PCSK_KEY);
+  });
+
+  it('redacts degradation_reason in query success responses', async () => {
+    mockedGetClient.mockReturnValue({
+      query: vi.fn().mockResolvedValue(
+        makeHybridQueryResult({
+          degraded: true,
+          degradation_reason: `rerank_failed: unauthorized ${PCSK_KEY}`,
+        })
+      ),
+      count: vi.fn(),
+    } as never);
+
+    const server = createMockServer();
+    registerQueryTool(server as never);
+
+    const body = parseToolJson(
+      await server.getHandler('query')!({
+        query_text: 'hello',
+        namespace: 'wg21',
+        top_k: 5,
+        preset: 'full',
+      })
+    );
+
+    expect(body.degradation_reason).not.toContain(PCSK_KEY);
+    expect(String(body.degradation_reason)).toContain('***');
+  });
+
+  it('preserves non-sensitive UUIDs in success payload metadata', async () => {
+    mockedGetClient.mockReturnValue({
+      query: vi.fn().mockResolvedValue(
+        makeHybridQueryResult({
+          results: [
+            makeSearchResult({
+              metadata: { document_id: UUID_KEY, title: 'Paper' },
+            }),
+          ],
+        })
+      ),
+      count: vi.fn(),
+    } as never);
+
+    const server = createMockServer();
+    registerQueryTool(server as never);
+
+    const body = parseToolJson(
+      await server.getHandler('query')!({
+        query_text: 'hello',
+        namespace: 'wg21',
+        top_k: 5,
+        preset: 'full',
+      })
+    );
+
+    const rows = body.results as Array<{ metadata: { document_id: string } }>;
+    expect(rows[0].metadata.document_id).toBe(UUID_KEY);
+  });
+
+  it('redacts degradation_reason in guided_query result', async () => {
+    const nsEntry = makeNamespaceCacheEntry('papers');
+    mockedGetNamespaces.mockResolvedValue({
+      data: [nsEntry],
+      cache_hit: false,
+      expires_at: Date.now() + 1_800_000,
+    });
+    mockedGetClient.mockReturnValue({
+      query: vi.fn().mockResolvedValue(
+        makeHybridQueryResult({
+          degraded: true,
+          degradation_reason: `rerank_failed: auth ${PCSK_KEY}`,
+        })
+      ),
+      count: vi.fn().mockResolvedValue({ count: 1, truncated: false }),
+    } as never);
+
+    const server = createMockServer();
+    registerGuidedQueryTool(server as never);
+
+    const body = parseToolJson(
+      await server.getHandler('guided_query')!({
+        user_query: 'What does the paper say about contracts?',
+        namespace: 'papers',
+        preferred_tool: 'detailed',
+      })
+    );
+
+    const result = body.result as Record<string, unknown>;
+    expect(result.degradation_reason).not.toContain(PCSK_KEY);
+    expect(String(result.degradation_reason)).toContain('***');
+  });
+
+  it('jsonResponse redacts nested degradation_reason without masking metadata UUIDs', () => {
+    const payload = jsonResponse({
+      status: 'success',
+      degradation_reason: `rerank_failed: ${PCSK_KEY}`,
+      results: [{ metadata: { document_id: UUID_KEY } }],
+    });
+    const text = payload.content[0]!.text;
+    expect(text).not.toContain(PCSK_KEY);
+    expect(text).toContain(UUID_KEY);
+  });
+});
+
+describe('query tool VALIDATION for malformed metadata_filter (redaction suite cross-check)', () => {
+  beforeEach(() => {
+    vi.spyOn(suggestionFlow, 'requireSuggested').mockReturnValue(flowOk);
+    mockedGetClient.mockReturnValue({
+      query: vi.fn(),
+      count: vi.fn(),
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns VALIDATION for empty $in', async () => {
+    const server = createMockServer();
+    registerQueryTool(server as never);
+    const raw = await server.getHandler('query')!({
+      query_text: 'hello',
+      namespace: 'wg21',
+      top_k: 5,
+      preset: 'full',
+      metadata_filter: { tags: { $in: [] } },
+    });
+    const err = assertToolErrorCode(raw, 'VALIDATION');
+    expect(err.field).toBe('tags.$in');
+  });
+});

--- a/src/core/server/tool-response.ts
+++ b/src/core/server/tool-response.ts
@@ -1,3 +1,4 @@
+import { redactSensitiveFields } from '../../logger.js';
 import type { ToolError } from './tool-error.js';
 import { toolErrorSchema } from './tool-error.js';
 
@@ -8,11 +9,12 @@ export type TextPayload = {
 
 /** Build an MCP tool success payload with JSON-stringified content. */
 export function jsonResponse(payload: unknown): TextPayload {
+  const safe = redactSensitiveFields(payload);
   return {
     content: [
       {
         type: 'text',
-        text: JSON.stringify(payload, null, 2),
+        text: JSON.stringify(safe, null, 2),
       },
     ],
   };
@@ -21,12 +23,13 @@ export function jsonResponse(payload: unknown): TextPayload {
 /** Build an MCP tool error payload with JSON-stringified {@link ToolError} and isError: true. */
 export function jsonErrorResponse(err: ToolError): TextPayload {
   const validated = toolErrorSchema.parse(err);
+  const safe = redactSensitiveFields(validated) as ToolError;
   return {
     isError: true,
     content: [
       {
         type: 'text',
-        text: JSON.stringify(validated, null, 2),
+        text: JSON.stringify(safe, null, 2),
       },
     ],
   };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -59,8 +59,41 @@ export function redactApiKey(s: string): string {
     /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g,
     '***'
   );
+  out = out.replace(/pcsk_[A-Za-z0-9_-]{40,}/g, '***');
   out = out.replace(/(api[_-]?key["':\s=]+)([^\s"',}]+)/gi, '$1***');
   out = out.replace(/(Authorization:\s*Bearer\s+)([^\s"',}]+)/gi, '$1***');
+  return out;
+}
+
+/** MCP response keys whose string values may carry SDK errors or credentials. */
+const SENSITIVE_RESPONSE_KEYS = new Set(['message', 'suggestion', 'degradation_reason']);
+
+/**
+ * Recursively redact sensitive string fields in MCP tool payloads.
+ * Only keys in {@link SENSITIVE_RESPONSE_KEYS} are masked; other strings (e.g. document UUIDs in metadata) are preserved.
+ */
+export function redactSensitiveFields(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet()
+): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== 'object') return value;
+
+  if (seen.has(value as object)) return '[Circular]';
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveFields(item, seen));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof nested === 'string' && SENSITIVE_RESPONSE_KEYS.has(key)) {
+      out[key] = redactApiKey(nested);
+    } else {
+      out[key] = redactSensitiveFields(nested, seen);
+    }
+  }
   return out;
 }
 


### PR DESCRIPTION
## Summary

Item 5 (week_plan_v1) closes two pre-1.0 security gaps: MCP tool responses now sanitize known credential-bearing fields before JSON serialization, and the metadata filter validator rejects degenerate/oversized inputs with structured errors instead of passing them through to Pinecone. Property-based fuzz tests (`fast-check`) and targeted redaction tests lock in the behavior.

## Issues addressed

- **#136** — credential redaction verification across MCP output paths 
- Close https://github.com/cppalliance/pinecone-read-only-mcp-typescript/issues/136 
- **#137** — metadata filter recursive validator fuzz testing 
- Close https://github.com/cppalliance/pinecone-read-only-mcp-typescript/issues/137 

## Changes

### 5a — Credential redaction

- `redactApiKey()` extended with `pcsk_[A-Za-z0-9_-]{40,}` pattern for modern Pinecone keys
- New exported `redactSensitiveFields()` — key-targeted walk over `message`, `suggestion`, `degradation_reason` (preserves document UUIDs in metadata)
- `jsonResponse` / `jsonErrorResponse` sanitize payloads before `JSON.stringify` (single choke point for all 9 tools)
- Defense-in-depth: `rerank.ts` redacts SDK error text when building `degradation_reason`
- `docs/SECURITY.md` documents MCP response redaction (not only stderr)

### 5b — Metadata filter hardening + fuzz

- `MAX_FILTER_DEPTH = 10` with explicit `depth` counter (depth 10 passes, 11 rejects)
- Reject empty `$and`, `$or`, `$in`, `$nin` with clear validation messages
- `fast-check` dev dependency + `metadata-filter.fuzz.test.ts` (4 properties × 100 runs)
- `metadata-filter.test.ts` regression cases for depth boundary and empty-array guards

## Acceptance criteria

### #136 (5a — redaction)

- [x] Tool error `message` and `suggestion` redacted in MCP responses
- [x] `HybridQueryResult.degradation_reason` redacted (`query` handler + `jsonResponse`)
- [x] `guided_query` response path redacts `result.degradation_reason` (sensitive fields flow through `jsonResponse`)
- [x] `classifyToolCatchError` catch-all redacted in DEBUG mode via `jsonErrorResponse`
- [x] Tests use realistic `pcsk_…` fixtures
- [x] Bypass paths fixed: `tool-response.ts`, `rerank.ts`, `logger.ts`

### #137 (5b — filter fuzz)

- [x] Fuzz coverage: depth 10+, empty combinators, `$in` 0/1000+, special field names, unknown operators, invalid `$in` elements
- [x] Malformed inputs return structured validator errors (no throw); end-to-end `VALIDATION` on `query` for empty `$in`
- [x] Valid complex filters (3+ nesting levels) pass unchanged
- [x] ≥ 100 generated cases via `fast-check`
- [x] Tests pass locally (211/211)
- [ ] PR approved by at least 1 reviewer

## Test plan

- [x] `npm test` — 211 tests pass
- [x] `npm run test:coverage` — passes
- [x] `npm run typecheck` / `npm run lint` / `npm run build` — pass
- [x] `redaction.test.ts` — `pcsk_`, UUID, Bearer, DEBUG-mode errors, degradation_reason, UUID preservation
- [x] `metadata-filter.fuzz.test.ts` — never-throws, malformed→error, valid grammar, special keys, large `$in`
- [x] `metadata-filter.test.ts` — depth 10/11 boundary, empty `$and`/`$or`/`$in`/`$nin`
- [ ] CI green on PR

## Notes for reviewers

- `redactSensitiveFields` is **not** the same as private `redactValue`: logs redact every string; MCP responses redact only allowlisted keys so search-result metadata UUIDs are preserved.
- `decision_trace.explanation` is intentionally excluded from the sensitive key list (routing text, not SDK error output).
- Depth is measured by an explicit `depth` parameter on `validateMetadataFilterRecord` (not `path.length`), incremented at each `$and`/`$or` nested record.- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced redaction of sensitive data in logs and tool responses, including additional API key token formats.

* **Bug Fixes**
  * Stricter validation for nested metadata filters with depth limits enforcement.
  * Improved error message sanitization to prevent API key exposure.

* **Documentation**
  * Updated security guidance for log redaction and response sanitization practices.

* **Tests**
  * Added comprehensive test coverage for redaction behavior and metadata filter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->