### PR TITLE
feat(setup): explicit context API for multi-instance ServerContext embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,16 +125,27 @@ Run `pinecone-read-only-mcp --help` for CLI equivalents (`--cache-ttl-seconds`, 
 
 ### Deployment model
 
-The server uses **process-global** memory for the suggest-flow gate (`suggest_query_params` context), namespaces cache, URL generator registry, and active configuration. **Stdio MCP (one client per Node process)** matches this model. If you embed `setupAllianceServer` behind a multi-tenant HTTP transport, isolate those structures per session yourself or treat the suggest-flow guard as best-effort only.
+Each **`ServerContext`** owns its own suggest-flow gate, namespaces cache, URL generator registry, and config. **Stdio MCP (one client per Node process)** typically uses one context. For **multi-tenant HTTP** embedding, create one `ServerContext` per session and pass it explicitly to `setupAllianceServer({ config, context: ctx })` or `setupCoreServer({ config, context: ctx })`.
+
+Legacy module getters (`setPineconeClient`, `registerUrlGenerator`, etc.) still delegate to a process-default context when you omit `context` at setup.
 
 ### Library embedding
 
-Treat **`setupCoreServer()` / `setupAllianceServer()` as one logical server per Node process**: they mutate shared module singletons (suggest-flow map, namespaces cache, URL registry, config context, shared `PineconeClient` slot). A **second** setup call in the same process **throws** unless you call **`teardownServer()`** first.
+**Recommended (instance-first):** create a `ServerContext`, inject the client, and pass it to setup:
 
-- **Generic bridge only:** `import { setupCoreServer, teardownServer, ... } from '@will-cppa/pinecone-read-only-mcp'`
+- **Generic bridge only:** `import { createServer, setupCoreServer, teardownServer, ... } from '@will-cppa/pinecone-read-only-mcp'`
 - **Full Alliance surface (CLI parity):** `import { setupAllianceServer, resolveAllianceConfig } from '@will-cppa/pinecone-read-only-mcp/alliance'`
 
-For the **generic bridge only**, see [examples/quickstart/mcp-demo.ts](examples/quickstart/mcp-demo.ts) (`setupCoreServer` + `resolveConfig` with required `indexName`; suggest-flow gate **off** by default). For the **full Alliance surface**, use `resolveAllianceConfig({ apiKey, ... })` (Alliance index/rerank defaults when omitted, suggest-flow gate **on** by default, same as the CLI) → `setPineconeClient(new PineconeClient(...))` → `await setupAllianceServer(config)` → connect one MCP transport. See [examples/alliance/library-embedding-demo.ts](examples/alliance/library-embedding-demo.ts) and [docs/TOOLS.md](docs/TOOLS.md#suggest-flow-gate).
+```ts
+const config = resolveAllianceConfig({ apiKey: '...' });
+const ctx = createServer(config);
+ctx.setClient(new PineconeClient({ /* ... */ }));
+const server = await setupAllianceServer({ config, context: ctx });
+```
+
+Use **`await using server = await setupAllianceServer({ config, context: ctx })`** for automatic teardown, or call **`ctx.teardown()`** when done. For legacy single-server flows that rely on the process-default context, **`teardownServer()`** resets that default before re-initializing.
+
+For the **generic bridge only**, see [examples/quickstart/mcp-demo.ts](examples/quickstart/mcp-demo.ts). For the **full Alliance surface**, see [examples/alliance/library-embedding-demo.ts](examples/alliance/library-embedding-demo.ts) and [docs/TOOLS.md](docs/TOOLS.md#suggest-flow-gate).
 
 ### Custom URL generators
 
@@ -144,16 +155,17 @@ Import `registerUrlGenerator` and types `UrlGeneratorFn` / `UrlGenerationResult`
 
 ```ts
 import {
+  createServer,
   PineconeClient,
   registerUrlGenerator,
-  setPineconeClient,
   type UrlGenerationResult,
   type UrlGeneratorFn,
 } from '@will-cppa/pinecone-read-only-mcp';
 import { resolveAllianceConfig, setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
 
 const config = resolveAllianceConfig({ apiKey: '...' }); // optional: indexName, rerankModel
-setPineconeClient(
+const ctx = createServer(config);
+ctx.setClient(
   new PineconeClient({
     apiKey: config.apiKey,
     indexName: config.indexName,
@@ -161,7 +173,7 @@ setPineconeClient(
     rerankModel: config.rerankModel,
   })
 );
-const server = await setupAllianceServer(config);
+const server = await setupAllianceServer({ config, context: ctx });
 
 const myDocs: UrlGeneratorFn = (metadata): UrlGenerationResult => {
   const id = typeof metadata.doc_id === 'string' ? metadata.doc_id : null;

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To try the server on **your own** Pinecone project (free tier, no Alliance index
 The codebase is split into two layers:
 
 - **`src/core/`** — generic MCP–Pinecone bridge (`PineconeClient`, `resolveConfig`, core MCP tools). Import from `@will-cppa/pinecone-read-only-mcp` (package root).
-- **`src/alliance/`** — C++ Alliance app tools (`suggest_query_params`, `guided_query`, Boost/Slack URL builtins). Import from `@will-cppa/pinecone-read-only-mcp/alliance` and call `setupAllianceServer(config)` for the full tool surface (what the CLI uses).
+- **`src/alliance/`** — C++ Alliance app tools (`suggest_query_params`, `guided_query`, Boost/Slack URL builtins). Import from `@will-cppa/pinecone-read-only-mcp/alliance`; embed via `resolveAllianceConfig` → `createServer` / `setClient` → `setupAllianceServer({ context: ctx })` (see [Library embedding](#library-embedding)).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ Run `pinecone-read-only-mcp --help` for CLI equivalents (`--cache-ttl-seconds`, 
 
 ### Deployment model
 
-Each **`ServerContext`** owns its own suggest-flow gate, namespaces cache, URL generator registry, and config. **Stdio MCP (one client per Node process)** typically uses one context. For **multi-tenant HTTP** embedding, create one `ServerContext` per session and pass it explicitly to `setupAllianceServer({ config, context: ctx })` or `setupCoreServer({ config, context: ctx })`.
+Each **`ServerContext`** owns its own suggest-flow gate, namespaces cache, URL generator registry, and config. **Stdio MCP (one client per Node process)** typically uses one context. For **multi-tenant HTTP** embedding, create one `ServerContext` per session and pass it explicitly to `setupAllianceServer({ context: ctx })` or `setupCoreServer({ context: ctx })`.
+
+Pass `config` at setup only when the context is not yet configured; after `createServer` + `setClient`, pass `{ context: ctx }` only.
 
 Legacy module getters (`setPineconeClient`, `registerUrlGenerator`, etc.) still delegate to a process-default context when you omit `context` at setup.
 
@@ -140,10 +142,10 @@ Legacy module getters (`setPineconeClient`, `registerUrlGenerator`, etc.) still 
 const config = resolveAllianceConfig({ apiKey: '...' });
 const ctx = createServer(config);
 ctx.setClient(new PineconeClient({ /* ... */ }));
-const server = await setupAllianceServer({ config, context: ctx });
+const server = await setupAllianceServer({ context: ctx });
 ```
 
-Use **`await using server = await setupAllianceServer({ config, context: ctx })`** for automatic teardown, or call **`ctx.teardown()`** when done. For legacy single-server flows that rely on the process-default context, **`teardownServer()`** resets that default before re-initializing.
+Use **`await using server = await setupAllianceServer({ context: ctx })`** for automatic teardown, or call **`ctx.teardown()`** when done. For legacy single-server flows that rely on the process-default context, **`teardownServer()`** resets that default before re-initializing.
 
 For the **generic bridge only**, see [examples/quickstart/mcp-demo.ts](examples/quickstart/mcp-demo.ts). For the **full Alliance surface**, see [examples/alliance/library-embedding-demo.ts](examples/alliance/library-embedding-demo.ts) and [docs/TOOLS.md](docs/TOOLS.md#suggest-flow-gate).
 
@@ -173,7 +175,7 @@ ctx.setClient(
     rerankModel: config.rerankModel,
   })
 );
-const server = await setupAllianceServer({ config, context: ctx });
+const server = await setupAllianceServer({ context: ctx });
 
 const myDocs: UrlGeneratorFn = (metadata): UrlGenerationResult => {
   const id = typeof metadata.doc_id === 'string' ? metadata.doc_id : null;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,7 +28,7 @@ Configuration is built from **CLI flags** (when using the binary), **environment
 
 **Throws** if `apiKey` or `indexName` is missing after trim.
 
-For the full Alliance tool surface (including `suggest_query_params`, `guided_query`, and built-in URL generators), import from `@will-cppa/pinecone-read-only-mcp/alliance` and call `setupAllianceServer(config)`.
+For the full Alliance tool surface (including `suggest_query_params`, `guided_query`, and built-in URL generators), import from `@will-cppa/pinecone-read-only-mcp/alliance` and follow the [Library embedding](#library-embedding) flow: `resolveAllianceConfig` → `createServer` / `setClient` → `setupAllianceServer({ context: ctx })`.
 
 ### Core vs Alliance resolvers
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -63,9 +63,9 @@ C++ Alliance deployers can copy [examples/alliance/.env.example](../examples/all
 
 ## Library embedding
 
-1. Build `ServerConfig` with `resolveConfig({ apiKey: '...', indexName: '...', ... })` or pass explicit overrides.
-2. Construct `PineconeClient` and `setPineconeClient(client)` before `setupAllianceServer(config)` (mirrors `src/index.ts`).
-3. `await setupAllianceServer(config)` (or `setupCoreServer` for generic tools only) then connect an MCP transport.
+1. Build `ServerConfig` with `resolveConfig({ apiKey: '...', indexName: '...', ... })` or `resolveAllianceConfig(...)` for the full tool surface.
+2. `const ctx = createServer(config)` then `ctx.setClient(new PineconeClient({ ... }))` (mirrors `src/index.ts`).
+3. `await setupAllianceServer({ config, context: ctx })` (or `setupCoreServer({ config, context: ctx })` for generic tools only) then connect an MCP transport.
 
 See [README deployment model](../README.md#deployment-model), [examples/quickstart/README.md](../examples/quickstart/README.md) (generic), and [examples/alliance/library-embedding-demo.ts](../examples/alliance/library-embedding-demo.ts) (Alliance surface).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -65,7 +65,9 @@ C++ Alliance deployers can copy [examples/alliance/.env.example](../examples/all
 
 1. Build `ServerConfig` with `resolveConfig({ apiKey: '...', indexName: '...', ... })` or `resolveAllianceConfig(...)` for the full tool surface.
 2. `const ctx = createServer(config)` then `ctx.setClient(new PineconeClient({ ... }))` (mirrors `src/index.ts`).
-3. `await setupAllianceServer({ config, context: ctx })` (or `setupCoreServer({ config, context: ctx })` for generic tools only) then connect an MCP transport.
+3. `await setupAllianceServer({ context: ctx })` (or `setupCoreServer({ context: ctx })` for generic tools only) then connect an MCP transport.
+
+Pass `config` at setup only when the context is not yet configured; after `createServer` + `setClient`, pass `{ context: ctx }` only.
 
 See [README deployment model](../README.md#deployment-model), [examples/quickstart/README.md](../examples/quickstart/README.md) (generic), and [examples/alliance/library-embedding-demo.ts](../examples/alliance/library-embedding-demo.ts) (Alliance surface).
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -30,7 +30,7 @@ const server = await setupAllianceServer(config);
 
 Module-level helpers (`getPineconeClient`, `registerUrlGenerator`, `requireSuggested`, etc.) continue to work; they delegate to a process-default context.
 
-**New (opt-in instance path):**
+**New (recommended — phase 4 explicit context at setup):**
 
 ```ts
 import { createServer, PineconeClient } from '@will-cppa/pinecone-read-only-mcp';
@@ -40,7 +40,7 @@ import {
 } from '@will-cppa/pinecone-read-only-mcp/alliance';
 
 const config = resolveAllianceConfig({ apiKey: process.env.PINECONE_API_KEY! });
-const ctx = createServer(config); // installs process-default + returns instance
+const ctx = createServer(config);
 ctx.setClient(
   new PineconeClient({
     apiKey: config.apiKey,
@@ -51,8 +51,21 @@ ctx.setClient(
     requestTimeoutMs: config.requestTimeoutMs,
   })
 );
-const server = await setupAllianceServer(config); // uses process-default ctx for migrated tools
+const server = await setupAllianceServer({ config, context: ctx });
 ```
+
+**Core-only setup** (seven tools, no Alliance builtins):
+
+```ts
+import { createServer, PineconeClient, resolveConfig, setupCoreServer } from '@will-cppa/pinecone-read-only-mcp';
+
+const config = resolveConfig({ apiKey: '...', indexName: 'my-index' });
+const ctx = createServer(config);
+ctx.setClient(new PineconeClient({ /* ... */ }));
+const server = await setupCoreServer({ config, context: ctx });
+```
+
+**Multi-instance:** run multiple `ServerContext` instances in one process by passing a distinct `context` to each setup call. Use `await using` on the returned `ServerHandle` or `ctx.teardown()` per session. Legacy `teardownServer()` resets only the process-default context.
 
 For custom tool wiring, pass `ctx` to migrated registrars:
 
@@ -61,7 +74,7 @@ import { registerQueryTool, registerCountTool, registerListNamespacesTool } from
 registerQueryTool(server, ctx);
 ```
 
-**Later (future minors/major):** Legacy module getters will be marked `### Deprecated` per [deprecation-policy.md](./deprecation-policy.md). Multi-tenant HTTP embedders should use one `ServerContext` per session rather than sharing process-global state.
+**Later (future minors/major):** Legacy module getters will be marked `### Deprecated` per [deprecation-policy.md](./deprecation-policy.md).
 
 See also [deprecation-policy.md § Future instance APIs](./deprecation-policy.md#future-instance-apis-servercontext).
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -51,8 +51,10 @@ ctx.setClient(
     requestTimeoutMs: config.requestTimeoutMs,
   })
 );
-const server = await setupAllianceServer({ config, context: ctx });
+const server = await setupAllianceServer({ context: ctx });
 ```
+
+Pass `config` at setup only when the context is not yet configured; after `createServer` + `setClient`, pass `{ context: ctx }` only.
 
 **Core-only setup** (seven tools, no Alliance builtins):
 
@@ -62,7 +64,7 @@ import { createServer, PineconeClient, resolveConfig, setupCoreServer } from '@w
 const config = resolveConfig({ apiKey: '...', indexName: 'my-index' });
 const ctx = createServer(config);
 ctx.setClient(new PineconeClient({ /* ... */ }));
-const server = await setupCoreServer({ config, context: ctx });
+const server = await setupCoreServer({ context: ctx });
 ```
 
 **Multi-instance:** run multiple `ServerContext` instances in one process by passing a distinct `context` to each setup call. Use `await using` on the returned `ServerHandle` or `ctx.teardown()` per session. Legacy `teardownServer()` resets only the process-default context.

--- a/examples/alliance/library-embedding-demo.ts
+++ b/examples/alliance/library-embedding-demo.ts
@@ -1,18 +1,22 @@
 /**
  * Library embedding: build the MCP server from a Node script (not the CLI).
  *
- * Pattern (mirrors `src/index.ts`):
+ * Instance-first pattern (mirrors `src/index.ts`):
  *   1. `resolveAllianceConfig({ apiKey, indexName, ... })` — Alliance index/rerank defaults when unset.
- *   2. `new PineconeClient({ ... })` + `setPineconeClient(client)` (legacy), or `createServer(config)` + `ctx.setClient(...)`.
- *   3. `await setupAllianceServer(config)` then `server.connect(transport)`.
+ *   2. `createServer(config)` → `ctx.setClient(new PineconeClient({ ... }))`.
+ *   3. `await setupAllianceServer({ config, context: ctx })` then `server.connect(transport)`.
  *
- * **Single process:** `setupAllianceServer` registers tools against process-global
- * singletons (suggest-flow state, namespaces cache, URL registry, active config).
- * A second setup call throws — call `teardownServer()` first to re-initialize
- * (tests). For isolated tenants in production, prefer one server per Node process.
+ * **Multi-instance:** pass a distinct `ServerContext` per tenant/session. Each context
+ * owns its own suggest-flow state, namespaces cache, and URL registry. Use
+ * `await using server = await setupAllianceServer({ config, context: ctx })` for
+ * automatic teardown, or call `ctx.teardown()` when done.
+ *
+ * **Legacy (single process-default server):** `setPineconeClient(client)` then
+ * `await setupAllianceServer(config)` still works; call `teardownServer()` before
+ * re-initializing the default context.
  */
 
-import { PineconeClient, setPineconeClient } from '@will-cppa/pinecone-read-only-mcp';
+import { createServer, PineconeClient } from '@will-cppa/pinecone-read-only-mcp';
 import { resolveAllianceConfig, setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
 
 async function main(): Promise<void> {
@@ -25,7 +29,8 @@ async function main(): Promise<void> {
   }
   const config = resolveAllianceConfig({ apiKey });
 
-  setPineconeClient(
+  const ctx = createServer(config);
+  ctx.setClient(
     new PineconeClient({
       apiKey: config.apiKey,
       indexName: config.indexName,
@@ -36,7 +41,7 @@ async function main(): Promise<void> {
     })
   );
 
-  const server = await setupAllianceServer(config);
+  const server = await setupAllianceServer({ config, context: ctx });
   // const transport = new StdioServerTransport();
   // await server.connect(transport);
   void server;

--- a/examples/alliance/library-embedding-demo.ts
+++ b/examples/alliance/library-embedding-demo.ts
@@ -4,11 +4,14 @@
  * Instance-first pattern (mirrors `src/index.ts`):
  *   1. `resolveAllianceConfig({ apiKey, indexName, ... })` — Alliance index/rerank defaults when unset.
  *   2. `createServer(config)` → `ctx.setClient(new PineconeClient({ ... }))`.
- *   3. `await setupAllianceServer({ config, context: ctx })` then `server.connect(transport)`.
+ *   3. `await setupAllianceServer({ context: ctx })` then `server.connect(transport)`.
+ *
+ * Pass `config` at setup only when the context is not yet configured; after
+ * `createServer` + `setClient`, pass `{ context: ctx }` only.
  *
  * **Multi-instance:** pass a distinct `ServerContext` per tenant/session. Each context
  * owns its own suggest-flow state, namespaces cache, and URL registry. Use
- * `await using server = await setupAllianceServer({ config, context: ctx })` for
+ * `await using server = await setupAllianceServer({ context: ctx })` for
  * automatic teardown, or call `ctx.teardown()` when done.
  *
  * **Legacy (single process-default server):** `setPineconeClient(client)` then
@@ -41,7 +44,7 @@ async function main(): Promise<void> {
     })
   );
 
-  const server = await setupAllianceServer({ config, context: ctx });
+  const server = await setupAllianceServer({ context: ctx });
   // const transport = new StdioServerTransport();
   // await server.connect(transport);
   void server;

--- a/src/alliance/index.ts
+++ b/src/alliance/index.ts
@@ -10,7 +10,7 @@ export {
   DEFAULT_ALLIANCE_RERANK_MODEL,
   resolveAllianceConfig,
 } from './config.js';
-export { setupAllianceServer } from './setup.js';
+export { setupAllianceServer, type SetupAllianceServerOptions } from './setup.js';
 export {
   registerBuiltinUrlGenerators,
   generatorMailing,

--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -1,6 +1,6 @@
 import { ALLIANCE_SERVER_INSTRUCTIONS } from '../constants.js';
 import type { ServerConfig } from '../core/config.js';
-import { getDefaultServerContext } from '../core/server/server-context.js';
+import { getDefaultServerContext, type ServerContext } from '../core/server/server-context.js';
 import { resolveAllianceConfig } from './config.js';
 import { setupCoreServer, type ServerHandle } from '../core/setup.js';
 import { registerBuiltinUrlGenerators } from './url-builtins.js';
@@ -8,18 +8,78 @@ import { registerGuidedQueryTool } from './tools/guided-query-tool.js';
 import { registerSuggestQueryParamsTool } from './tools/suggest-query-params-tool.js';
 
 /**
+ * Options for {@link setupAllianceServer}.
+ */
+export type SetupAllianceServerOptions = {
+  config?: ServerConfig;
+  context?: ServerContext;
+  /** MCP server instructions; defaults to {@link ALLIANCE_SERVER_INSTRUCTIONS}. */
+  instructions?: string;
+};
+
+function isServerConfig(value: unknown): value is ServerConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as ServerConfig).apiKey === 'string' &&
+    typeof (value as ServerConfig).indexName === 'string'
+  );
+}
+
+function isSetupAllianceServerOptions(value: unknown): value is SetupAllianceServerOptions {
+  return typeof value === 'object' && value !== null && !isServerConfig(value);
+}
+
+function normalizeSetupAllianceArgs(
+  configOrOptions?: ServerConfig | SetupAllianceServerOptions,
+  legacyOptions?: Pick<SetupAllianceServerOptions, 'instructions'>
+): SetupAllianceServerOptions {
+  if (configOrOptions === undefined) {
+    return legacyOptions ?? {};
+  }
+  if (isServerConfig(configOrOptions)) {
+    return { config: configOrOptions, ...legacyOptions };
+  }
+  if (isSetupAllianceServerOptions(configOrOptions)) {
+    return { ...configOrOptions, ...legacyOptions };
+  }
+  return legacyOptions ?? {};
+}
+
+/**
  * Create and configure the MCP server with the full Alliance tool surface:
  * all core tools plus `suggest_query_params`, `guided_query`, and built-in URL generators.
  *
  * When `config` is omitted, resolves env via {@link resolveAllianceConfig} (Alliance index/rerank defaults when unset).
  */
-export async function setupAllianceServer(config?: ServerConfig): Promise<ServerHandle> {
-  const server = await setupCoreServer(config ?? resolveAllianceConfig({}), {
-    instructions: ALLIANCE_SERVER_INSTRUCTIONS,
-  });
-  const ctx = getDefaultServerContext();
-  registerBuiltinUrlGenerators(ctx);
-  registerSuggestQueryParamsTool(server, ctx);
-  registerGuidedQueryTool(server, ctx);
+export async function setupAllianceServer(
+  configOrOptions?: ServerConfig | SetupAllianceServerOptions,
+  legacyOptions?: Pick<SetupAllianceServerOptions, 'instructions'>
+): Promise<ServerHandle> {
+  const opts = normalizeSetupAllianceArgs(configOrOptions, legacyOptions);
+  const instructions = opts.instructions ?? ALLIANCE_SERVER_INSTRUCTIONS;
+  const config = opts.config ?? resolveAllianceConfig({});
+
+  let server: ServerHandle;
+  let resolvedCtx: ServerContext;
+
+  if (opts.context) {
+    resolvedCtx = opts.context;
+    server = await setupCoreServer({
+      config: opts.config ?? config,
+      context: resolvedCtx,
+      instructions,
+    });
+  } else {
+    server = await setupCoreServer({
+      config: opts.config ?? config,
+      instructions,
+    });
+    resolvedCtx = getDefaultServerContext();
+  }
+
+  registerBuiltinUrlGenerators(resolvedCtx);
+  registerSuggestQueryParamsTool(server, resolvedCtx);
+  registerGuidedQueryTool(server, resolvedCtx);
   return server;
 }

--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -2,7 +2,7 @@ import { ALLIANCE_SERVER_INSTRUCTIONS } from '../constants.js';
 import type { ServerConfig } from '../core/config.js';
 import { getDefaultServerContext, type ServerContext } from '../core/server/server-context.js';
 import { resolveAllianceConfig } from './config.js';
-import { setupCoreServer, type ServerHandle } from '../core/setup.js';
+import { setupCoreServer, type ServerHandle, type SetupCoreServerOptions } from '../core/setup.js';
 import { registerBuiltinUrlGenerators } from './url-builtins.js';
 import { registerGuidedQueryTool } from './tools/guided-query-tool.js';
 import { registerSuggestQueryParamsTool } from './tools/suggest-query-params-tool.js';
@@ -27,7 +27,15 @@ function isServerConfig(value: unknown): value is ServerConfig {
 }
 
 function isSetupAllianceServerOptions(value: unknown): value is SetupAllianceServerOptions {
-  return typeof value === 'object' && value !== null && !isServerConfig(value);
+  if (typeof value !== 'object' || value === null || isServerConfig(value)) {
+    return false;
+  }
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    if (key !== 'config' && key !== 'context' && key !== 'instructions') {
+      return false;
+    }
+  }
+  return true;
 }
 
 function normalizeSetupAllianceArgs(
@@ -43,7 +51,7 @@ function normalizeSetupAllianceArgs(
   if (isSetupAllianceServerOptions(configOrOptions)) {
     return { ...configOrOptions, ...legacyOptions };
   }
-  return legacyOptions ?? {};
+  throw new TypeError('configOrOptions must be a ServerConfig or SetupAllianceServerOptions');
 }
 
 /**
@@ -58,19 +66,19 @@ export async function setupAllianceServer(
 ): Promise<ServerHandle> {
   const opts = normalizeSetupAllianceArgs(configOrOptions, legacyOptions);
   const instructions = opts.instructions ?? ALLIANCE_SERVER_INSTRUCTIONS;
-  const config = opts.config ?? resolveAllianceConfig({});
 
   let server: ServerHandle;
   let resolvedCtx: ServerContext;
 
   if (opts.context) {
     resolvedCtx = opts.context;
-    server = await setupCoreServer({
-      config: opts.config ?? config,
-      context: resolvedCtx,
-      instructions,
-    });
+    const coreOpts: SetupCoreServerOptions = { context: resolvedCtx, instructions };
+    if (opts.config !== undefined) {
+      coreOpts.config = opts.config;
+    }
+    server = await setupCoreServer(coreOpts);
   } else {
+    const config = opts.config ?? resolveAllianceConfig({});
     server = await setupCoreServer({
       config: opts.config ?? config,
       instructions,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -41,4 +41,9 @@ export type {
   HybridQueryResult,
   HybridLegFailed,
 } from '../types.js';
-export { setupCoreServer, teardownServer, type ServerHandle } from './setup.js';
+export {
+  setupCoreServer,
+  teardownServer,
+  type ServerHandle,
+  type SetupCoreServerOptions,
+} from './setup.js';

--- a/src/core/server/server-context.test.ts
+++ b/src/core/server/server-context.test.ts
@@ -21,6 +21,8 @@ describe('ServerContext', () => {
     const client = ctx.getClient();
     expect(client).toBeInstanceOf(PineconeClient);
     expect(ctx.getClient()).toBe(client);
+    expect(ctx.hasInjectedClient()).toBe(false);
+    expect(() => ctx.getClientIfSet()).toThrow(/not initialized/);
   });
 
   it('honors externally injected client via setClient and fromClient', () => {
@@ -31,9 +33,11 @@ describe('ServerContext', () => {
     viaSetter.setClient(injected);
     expect(viaSetter.getClient()).toBe(injected);
     expect(viaSetter.getClientIfSet()).toBe(injected);
+    expect(viaSetter.hasInjectedClient()).toBe(true);
 
     const viaFactory = ServerContext.fromClient(config, injected);
     expect(viaFactory.getClient()).toBe(injected);
+    expect(viaFactory.hasInjectedClient()).toBe(true);
   });
 
   it('createServer installs default context', () => {

--- a/src/core/server/server-context.ts
+++ b/src/core/server/server-context.ts
@@ -45,6 +45,7 @@ function buildPineconeClient(config: ServerConfig): PineconeClient {
  */
 export class ServerContext implements AsyncDisposable {
   disposed = false;
+  private toolsRegistered = false;
   private client: PineconeClient | null = null;
   private configValue: ServerConfig | null = null;
   private readonly urlGenerators = new Map<string, UrlGeneratorFn>();
@@ -256,9 +257,32 @@ export class ServerContext implements AsyncDisposable {
     this.namespacesCache = null;
   }
 
+  /** Whether MCP tools have been registered on this context (setup guard). */
+  hasToolsRegistered(): boolean {
+    return this.toolsRegistered;
+  }
+
+  /** Throw if this context cannot accept another tool registration pass. */
+  assertCanRegisterTools(): void {
+    if (this.disposed) {
+      throw new Error('Cannot setup a disposed ServerContext. Create a new instance.');
+    }
+    if (this.toolsRegistered) {
+      throw new Error(
+        'MCP tools already registered on this ServerContext. Call teardown/dispose first.'
+      );
+    }
+  }
+
+  /** Mark that MCP tools have been registered on this context. */
+  markToolsRegistered(): void {
+    this.toolsRegistered = true;
+  }
+
   /** Clear all encapsulated state (client handle, caches, registries). */
   teardown(): void {
     this.disposed = true;
+    this.toolsRegistered = false;
     this.client = null;
     this.configValue = null;
     this.urlGenerators.clear();
@@ -277,6 +301,11 @@ export class ServerContext implements AsyncDisposable {
 
 let defaultContext: ServerContext | null = null;
 let pendingConfig: ServerConfig | null = null;
+
+/** Peek at the process-default context without materializing a new one. */
+export function peekDefaultServerContext(): ServerContext | null {
+  return defaultContext;
+}
 
 /** Process-default context used by legacy module facades. */
 export function getDefaultServerContext(): ServerContext {

--- a/src/core/server/server-context.ts
+++ b/src/core/server/server-context.ts
@@ -47,6 +47,7 @@ export class ServerContext implements AsyncDisposable {
   disposed = false;
   private toolsRegistered = false;
   private client: PineconeClient | null = null;
+  private clientExplicitlySet = false;
   private configValue: ServerConfig | null = null;
   private readonly urlGenerators = new Map<string, UrlGeneratorFn>();
   private readonly suggestionFlow = new Map<string, FlowState>();
@@ -58,6 +59,7 @@ export class ServerContext implements AsyncDisposable {
     }
     if (client) {
       this.client = client;
+      this.clientExplicitlySet = true;
     }
   }
 
@@ -81,26 +83,29 @@ export class ServerContext implements AsyncDisposable {
   /** Drop client, namespace cache, and suggest-flow tied to a previous config. */
   private invalidateConfigDerivedState(): void {
     this.client = null;
+    this.clientExplicitlySet = false;
     this.namespacesCache = null;
     this.suggestionFlow.clear();
   }
 
   setClient(client: PineconeClient): void {
     this.client = client;
+    this.clientExplicitlySet = true;
   }
 
   clearClient(): void {
     this.client = null;
+    this.clientExplicitlySet = false;
   }
 
-  /** Whether a Pinecone client was explicitly set (does not lazy-build from config). */
+  /** Whether a Pinecone client was explicitly set via constructor, {@link setClient}, or {@link fromClient}. */
   hasInjectedClient(): boolean {
-    return this.client !== null;
+    return this.clientExplicitlySet;
   }
 
-  /** Return the client only when explicitly set (legacy {@link getPineconeClient} path). */
+  /** Return the client only when explicitly injected (legacy {@link getPineconeClient} path). */
   getClientIfSet(): PineconeClient {
-    if (!this.client) {
+    if (!this.clientExplicitlySet || !this.client) {
       throw new Error('Pinecone client not initialized. Call setPineconeClient first.');
     }
     return this.client;
@@ -289,6 +294,7 @@ export class ServerContext implements AsyncDisposable {
     this.disposed = true;
     this.toolsRegistered = false;
     this.client = null;
+    this.clientExplicitlySet = false;
     this.configValue = null;
     this.urlGenerators.clear();
     this.suggestionFlow.clear();

--- a/src/core/server/server-context.ts
+++ b/src/core/server/server-context.ts
@@ -93,6 +93,11 @@ export class ServerContext implements AsyncDisposable {
     this.client = null;
   }
 
+  /** Whether a Pinecone client was explicitly set (does not lazy-build from config). */
+  hasInjectedClient(): boolean {
+    return this.client !== null;
+  }
+
   /** Return the client only when explicitly set (legacy {@link getPineconeClient} path). */
   getClientIfSet(): PineconeClient {
     if (!this.client) {

--- a/src/core/setup-guards.test.ts
+++ b/src/core/setup-guards.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { setupAllianceServer } from '../alliance/setup.js';
-import { setupCoreServer, teardownServer } from './setup.js';
+import { setPineconeClient, setupCoreServer, teardownServer } from './index.js';
+import {
+  ServerContext,
+  getDefaultServerContext,
+  setDefaultServerContext,
+} from './server/server-context.js';
 import {
   createTestServerContext,
   isolateFromDefaultContext,
@@ -23,6 +28,18 @@ describe('setup guards (CodeRabbit PR #150)', () => {
     expect(ctx.getClient()).toBe(mockClient);
   });
 
+  it('allows config update when context only has a lazy-built client', async () => {
+    isolateFromDefaultContext();
+    const cfgA = resolveTestConfig({ apiKey: 'lazy-config-a', indexName: 'idx-a' });
+    const cfgB = resolveTestConfig({ apiKey: 'lazy-config-b', indexName: 'idx-b' });
+    const ctx = createTestServerContext({ config: cfgA });
+    ctx.getClient();
+    expect(ctx.hasInjectedClient()).toBe(false);
+
+    await expect(setupCoreServer({ config: cfgB, context: ctx })).resolves.toBeDefined();
+    expect(ctx.getConfig().indexName).toBe('idx-b');
+  });
+
   it('throws when setupCoreServer receives both config and context with injected client', async () => {
     isolateFromDefaultContext();
     const mockClient = { query: vi.fn() };
@@ -33,6 +50,36 @@ describe('setup guards (CodeRabbit PR #150)', () => {
       /injected Pinecone client/
     );
     expect(ctx.getClient()).toBe(mockClient);
+  });
+
+  it('does not reuse a lazy-built client from the default context on legacy setup', async () => {
+    isolateFromDefaultContext();
+    const cfgA = resolveTestConfig({ apiKey: 'reuse-lazy-a', indexName: 'idx-a' });
+    const cfgB = resolveTestConfig({ apiKey: 'reuse-lazy-b', indexName: 'idx-b' });
+
+    const defaultCtx = new ServerContext(cfgA);
+    const lazyClient = defaultCtx.getClient();
+    expect(defaultCtx.hasInjectedClient()).toBe(false);
+    setDefaultServerContext(defaultCtx);
+
+    await setupCoreServer(cfgB);
+
+    const newCtx = getDefaultServerContext();
+    expect(newCtx.getConfig().indexName).toBe('idx-b');
+    expect(newCtx.hasInjectedClient()).toBe(false);
+    expect(newCtx.getClient()).not.toBe(lazyClient);
+  });
+
+  it('reuses an explicitly injected client on legacy setup', async () => {
+    isolateFromDefaultContext();
+    const cfgB = resolveTestConfig({ apiKey: 'reuse-explicit-b', indexName: 'idx-b' });
+    const injected = { query: vi.fn() };
+    setPineconeClient(injected as never);
+
+    await setupCoreServer(cfgB);
+
+    expect(getDefaultServerContext().getClient()).toBe(injected);
+    expect(getDefaultServerContext().hasInjectedClient()).toBe(true);
   });
 
   it('throws TypeError for invalid setupCoreServer options object', async () => {

--- a/src/core/setup-guards.test.ts
+++ b/src/core/setup-guards.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setupAllianceServer } from '../alliance/setup.js';
+import { setupCoreServer, teardownServer } from './setup.js';
+import {
+  createTestServerContext,
+  isolateFromDefaultContext,
+  resolveTestConfig,
+} from './server/tools/test-helpers.js';
+
+describe('setup guards (CodeRabbit PR #150)', () => {
+  afterEach(() => {
+    teardownServer();
+    isolateFromDefaultContext();
+  });
+
+  it('preserves injected client when setupAllianceServer receives context only', async () => {
+    isolateFromDefaultContext();
+    const mockClient = { query: vi.fn() };
+    const ctx = createTestServerContext({ client: mockClient as never });
+
+    await setupAllianceServer({ context: ctx });
+
+    expect(ctx.getClient()).toBe(mockClient);
+  });
+
+  it('throws when setupCoreServer receives both config and context with injected client', async () => {
+    isolateFromDefaultContext();
+    const mockClient = { query: vi.fn() };
+    const cfg = resolveTestConfig({ apiKey: 'guard-config-context' });
+    const ctx = createTestServerContext({ config: cfg, client: mockClient as never });
+
+    await expect(setupCoreServer({ config: cfg, context: ctx })).rejects.toThrow(
+      /injected Pinecone client/
+    );
+    expect(ctx.getClient()).toBe(mockClient);
+  });
+
+  it('throws TypeError for invalid setupCoreServer options object', async () => {
+    await expect(setupCoreServer({ foo: 'bar' } as never)).rejects.toThrow(
+      /ServerConfig or SetupCoreServerOptions/
+    );
+  });
+
+  it('throws TypeError for invalid setupAllianceServer options object', async () => {
+    await expect(setupAllianceServer({ foo: 'bar' } as never)).rejects.toThrow(
+      /ServerConfig or SetupAllianceServerOptions/
+    );
+  });
+});

--- a/src/core/setup-multi-instance.test.ts
+++ b/src/core/setup-multi-instance.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveAllianceConfig } from '../alliance/config.js';
+import { setupAllianceServer } from '../alliance/setup.js';
+import { setupCoreServer, teardownServer } from './setup.js';
+import {
+  createTestServerContext,
+  isolateFromDefaultContext,
+  resolveTestConfig,
+} from './server/tools/test-helpers.js';
+
+const MAILING_DOC_ID = 'boost-announce@lists.boost.org/message/O5VYCDZADVDHK5Z5LAYJBHMDOAFQL7P6';
+
+describe('setup multi-instance (phase 4)', () => {
+  afterEach(() => {
+    teardownServer();
+    isolateFromDefaultContext();
+  });
+
+  it('allows two ServerContext instances to register tools without teardown between them', async () => {
+    isolateFromDefaultContext();
+    const cfgA = resolveTestConfig({ apiKey: 'multi-setup-a' });
+    const cfgB = resolveAllianceConfig({ apiKey: 'multi-setup-b', indexName: 'idx-b' });
+    const ctxA = createTestServerContext({ config: cfgA });
+    const ctxB = createTestServerContext({ config: cfgB });
+
+    await expect(setupCoreServer({ context: ctxA, config: cfgA })).resolves.toBeDefined();
+    await expect(
+      setupAllianceServer({ context: ctxB, config: cfgB })
+    ).resolves.toBeDefined();
+  });
+
+  it('isolates URL registry between instances', async () => {
+    isolateFromDefaultContext();
+    const cfgA = resolveTestConfig({ apiKey: 'url-iso-a' });
+    const cfgB = resolveAllianceConfig({ apiKey: 'url-iso-b', indexName: 'idx-b' });
+    const ctxA = createTestServerContext({ config: cfgA });
+    const ctxB = createTestServerContext({ config: cfgB });
+
+    await setupCoreServer({ context: ctxA, config: cfgA });
+    await setupAllianceServer({ context: ctxB, config: cfgB });
+
+    const metadata = { doc_id: MAILING_DOC_ID };
+    const fromA = ctxA.generateUrlForNamespace('mailing', metadata);
+    const fromB = ctxB.generateUrlForNamespace('mailing', metadata);
+
+    expect(fromA.method).toBe('unavailable');
+    expect(fromA.url).toBeNull();
+    expect(fromB.method).toBe('generated.mailing');
+    expect(fromB.url).toContain('lists.boost.org');
+  });
+
+  it('isolates suggest-flow between instances', async () => {
+    isolateFromDefaultContext();
+    const cfgA = resolveTestConfig({ apiKey: 'flow-iso-a', disableSuggestFlow: false });
+    const cfgB = resolveTestConfig({ apiKey: 'flow-iso-b', disableSuggestFlow: false });
+    const ctxA = createTestServerContext({ config: cfgA });
+    const ctxB = createTestServerContext({ config: cfgB });
+
+    await setupCoreServer({ context: ctxA, config: cfgA });
+    await setupCoreServer({ context: ctxB, config: cfgB });
+
+    ctxA.markSuggested('wg21', {
+      recommended_tool: 'fast',
+      suggested_fields: ['title'],
+      user_query: 'papers',
+    });
+
+    const resultB = ctxB.requireSuggested('wg21');
+    expect(resultB.ok).toBe(false);
+    if (!resultB.ok) {
+      expect(resultB.message).toContain('suggest_query_params');
+    }
+  });
+
+  it('isolates namespaces cache between instances', async () => {
+    isolateFromDefaultContext();
+    const listNsA = vi.fn().mockResolvedValue([
+      { namespace: 'wg21', recordCount: 10, metadata: { source: 'a' } },
+    ]);
+    const listNsB = vi.fn().mockResolvedValue([
+      { namespace: 'other', recordCount: 5, metadata: { source: 'b' } },
+    ]);
+    const cfgA = resolveTestConfig({ apiKey: 'cache-iso-a' });
+    const cfgB = resolveTestConfig({ apiKey: 'cache-iso-b' });
+    const ctxA = createTestServerContext({
+      config: cfgA,
+      client: { listNamespacesWithMetadata: listNsA } as never,
+    });
+    const ctxB = createTestServerContext({
+      config: cfgB,
+      client: { listNamespacesWithMetadata: listNsB } as never,
+    });
+
+    // Contexts already carry config; omit config at setup to preserve injected clients.
+    await setupCoreServer({ context: ctxA });
+    await setupCoreServer({ context: ctxB });
+
+    const resultA = await ctxA.getNamespacesWithCache();
+    expect(resultA.cache_hit).toBe(false);
+    expect(listNsA).toHaveBeenCalledTimes(1);
+
+    const resultB = await ctxB.getNamespacesWithCache();
+    expect(resultB.cache_hit).toBe(false);
+    expect(listNsB).toHaveBeenCalledTimes(1);
+    expect(listNsA).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves externally injected client when context is provided', async () => {
+    isolateFromDefaultContext();
+    const mockClient = { query: vi.fn() };
+    const ctx = createTestServerContext({ client: mockClient as never });
+
+    await setupCoreServer({ context: ctx });
+
+    expect(ctx.getClient()).toBe(mockClient);
+  });
+
+  it('await using disposes only the bound context; another instance can still setup', async () => {
+    isolateFromDefaultContext();
+    const ctxA = createTestServerContext({ config: resolveTestConfig({ apiKey: 'await-using-a' }) });
+    {
+      await using _handle = await setupCoreServer({ context: ctxA });
+      expect(ctxA.disposed).toBe(false);
+    }
+    expect(ctxA.disposed).toBe(true);
+
+    const ctxB = createTestServerContext({ config: resolveTestConfig({ apiKey: 'await-using-b' }) });
+    await expect(setupCoreServer({ context: ctxB })).resolves.toBeDefined();
+    expect(ctxB.disposed).toBe(false);
+  });
+});

--- a/src/core/setup-multi-instance.test.ts
+++ b/src/core/setup-multi-instance.test.ts
@@ -23,8 +23,8 @@ describe('setup multi-instance (phase 4)', () => {
     const ctxA = createTestServerContext({ config: cfgA });
     const ctxB = createTestServerContext({ config: cfgB });
 
-    await expect(setupCoreServer({ context: ctxA, config: cfgA })).resolves.toBeDefined();
-    await expect(setupAllianceServer({ context: ctxB, config: cfgB })).resolves.toBeDefined();
+    await expect(setupCoreServer({ context: ctxA })).resolves.toBeDefined();
+    await expect(setupAllianceServer({ context: ctxB })).resolves.toBeDefined();
   });
 
   it('isolates URL registry between instances', async () => {
@@ -34,8 +34,8 @@ describe('setup multi-instance (phase 4)', () => {
     const ctxA = createTestServerContext({ config: cfgA });
     const ctxB = createTestServerContext({ config: cfgB });
 
-    await setupCoreServer({ context: ctxA, config: cfgA });
-    await setupAllianceServer({ context: ctxB, config: cfgB });
+    await setupCoreServer({ context: ctxA });
+    await setupAllianceServer({ context: ctxB });
 
     const metadata = { doc_id: MAILING_DOC_ID };
     const fromA = ctxA.generateUrlForNamespace('mailing', metadata);
@@ -54,8 +54,8 @@ describe('setup multi-instance (phase 4)', () => {
     const ctxA = createTestServerContext({ config: cfgA });
     const ctxB = createTestServerContext({ config: cfgB });
 
-    await setupCoreServer({ context: ctxA, config: cfgA });
-    await setupCoreServer({ context: ctxB, config: cfgB });
+    await setupCoreServer({ context: ctxA });
+    await setupCoreServer({ context: ctxB });
 
     ctxA.markSuggested('wg21', {
       recommended_tool: 'fast',

--- a/src/core/setup-multi-instance.test.ts
+++ b/src/core/setup-multi-instance.test.ts
@@ -24,9 +24,7 @@ describe('setup multi-instance (phase 4)', () => {
     const ctxB = createTestServerContext({ config: cfgB });
 
     await expect(setupCoreServer({ context: ctxA, config: cfgA })).resolves.toBeDefined();
-    await expect(
-      setupAllianceServer({ context: ctxB, config: cfgB })
-    ).resolves.toBeDefined();
+    await expect(setupAllianceServer({ context: ctxB, config: cfgB })).resolves.toBeDefined();
   });
 
   it('isolates URL registry between instances', async () => {
@@ -74,12 +72,12 @@ describe('setup multi-instance (phase 4)', () => {
 
   it('isolates namespaces cache between instances', async () => {
     isolateFromDefaultContext();
-    const listNsA = vi.fn().mockResolvedValue([
-      { namespace: 'wg21', recordCount: 10, metadata: { source: 'a' } },
-    ]);
-    const listNsB = vi.fn().mockResolvedValue([
-      { namespace: 'other', recordCount: 5, metadata: { source: 'b' } },
-    ]);
+    const listNsA = vi
+      .fn()
+      .mockResolvedValue([{ namespace: 'wg21', recordCount: 10, metadata: { source: 'a' } }]);
+    const listNsB = vi
+      .fn()
+      .mockResolvedValue([{ namespace: 'other', recordCount: 5, metadata: { source: 'b' } }]);
     const cfgA = resolveTestConfig({ apiKey: 'cache-iso-a' });
     const cfgB = resolveTestConfig({ apiKey: 'cache-iso-b' });
     const ctxA = createTestServerContext({
@@ -117,14 +115,18 @@ describe('setup multi-instance (phase 4)', () => {
 
   it('await using disposes only the bound context; another instance can still setup', async () => {
     isolateFromDefaultContext();
-    const ctxA = createTestServerContext({ config: resolveTestConfig({ apiKey: 'await-using-a' }) });
+    const ctxA = createTestServerContext({
+      config: resolveTestConfig({ apiKey: 'await-using-a' }),
+    });
     {
       await using _handle = await setupCoreServer({ context: ctxA });
       expect(ctxA.disposed).toBe(false);
     }
     expect(ctxA.disposed).toBe(true);
 
-    const ctxB = createTestServerContext({ config: resolveTestConfig({ apiKey: 'await-using-b' }) });
+    const ctxB = createTestServerContext({
+      config: resolveTestConfig({ apiKey: 'await-using-b' }),
+    });
     await expect(setupCoreServer({ context: ctxB })).resolves.toBeDefined();
     expect(ctxB.disposed).toBe(false);
   });

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -5,6 +5,7 @@ import { PineconeClient } from './pinecone-client.js';
 import {
   createServer,
   getDefaultServerContext,
+  peekDefaultServerContext,
   teardownDefaultServerContext,
   type ServerContext,
 } from './server/server-context.js';
@@ -16,18 +17,16 @@ import { registerNamespaceRouterTool } from './server/tools/namespace-router-too
 import { registerQueryDocumentsTool } from './server/tools/query-documents-tool.js';
 import { registerQueryTool } from './server/tools/query-tool.js';
 
-let mcpServerInitialized = false;
-
 /** MCP server handle with automatic teardown via `await using`. */
 export type ServerHandle = McpServer & AsyncDisposable;
 
 /**
  * Reset process-global MCP server state (suggest-flow, namespace cache, active config,
- * Pinecone client handle, URL generator registry). Call before a second {@link setupCoreServer}.
+ * Pinecone client handle, URL generator registry). Call before a second legacy
+ * {@link setupCoreServer} that reuses the process-default context.
  */
 export function teardownServer(): void {
   teardownDefaultServerContext();
-  mcpServerInitialized = false;
 }
 
 /**
@@ -38,35 +37,80 @@ export function teardownServer(): void {
  * `@will-cppa/pinecone-read-only-mcp/alliance` for the full tool surface.
  */
 export type SetupCoreServerOptions = {
+  config?: ServerConfig;
+  context?: ServerContext;
   /** MCP server instructions; defaults to {@link CORE_SERVER_INSTRUCTIONS}. */
   instructions?: string;
 };
 
-export async function setupCoreServer(
-  config?: ServerConfig,
-  options?: SetupCoreServerOptions
-): Promise<ServerHandle> {
-  if (mcpServerInitialized) {
-    throw new Error(
-      'setupCoreServer() already called in this process. The MCP server uses process-global state (suggest-flow, namespace cache, URL generators, config). Call teardownServer() first if you need to re-initialize.'
-    );
+function isServerConfig(value: unknown): value is ServerConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as ServerConfig).apiKey === 'string' &&
+    typeof (value as ServerConfig).indexName === 'string'
+  );
+}
+
+function isSetupCoreServerOptions(value: unknown): value is SetupCoreServerOptions {
+  return typeof value === 'object' && value !== null && !isServerConfig(value);
+}
+
+function normalizeSetupCoreServerArgs(
+  configOrOptions?: ServerConfig | SetupCoreServerOptions,
+  legacyOptions?: Pick<SetupCoreServerOptions, 'instructions'>
+): SetupCoreServerOptions {
+  if (configOrOptions === undefined) {
+    return legacyOptions ?? {};
+  }
+  if (isServerConfig(configOrOptions)) {
+    return { config: configOrOptions, ...legacyOptions };
+  }
+  if (isSetupCoreServerOptions(configOrOptions)) {
+    return { ...configOrOptions, ...legacyOptions };
+  }
+  return legacyOptions ?? {};
+}
+
+function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
+  if (opts.context) {
+    if (opts.config) {
+      opts.context.setConfig(opts.config);
+    }
+    return opts.context;
   }
 
-  let ctx: ServerContext;
-  if (config) {
+  if (opts.config) {
+    const existingDefault = peekDefaultServerContext();
+    if (existingDefault?.hasToolsRegistered()) {
+      throw new Error(
+        'setupCoreServer() already called in this process. Call teardownServer() first if you need to re-initialize.'
+      );
+    }
+
     let existingClient: PineconeClient | undefined;
     try {
       existingClient = getDefaultServerContext().getClientIfSet();
     } catch {
       existingClient = undefined;
     }
-    ctx = createServer(config);
+    const ctx = createServer(opts.config);
     if (existingClient) {
       ctx.setClient(existingClient);
     }
-  } else {
-    ctx = getDefaultServerContext();
+    return ctx;
   }
+
+  return getDefaultServerContext();
+}
+
+export async function setupCoreServer(
+  configOrOptions?: ServerConfig | SetupCoreServerOptions,
+  legacyOptions?: Pick<SetupCoreServerOptions, 'instructions'>
+): Promise<ServerHandle> {
+  const opts = normalizeSetupCoreServerArgs(configOrOptions, legacyOptions);
+  const ctx = resolveSetupContext(opts);
+  ctx.assertCanRegisterTools();
 
   const server = new McpServer(
     {
@@ -74,7 +118,7 @@ export async function setupCoreServer(
       version: SERVER_VERSION,
     },
     {
-      instructions: options?.instructions ?? CORE_SERVER_INSTRUCTIONS,
+      instructions: opts.instructions ?? CORE_SERVER_INSTRUCTIONS,
     }
   );
 
@@ -86,14 +130,11 @@ export async function setupCoreServer(
   registerQueryDocumentsTool(server, ctx);
   registerGenerateUrlsTool(server, ctx);
 
+  ctx.markToolsRegistered();
+
   const handle = server as ServerHandle;
   handle[Symbol.asyncDispose] = async () => {
-    try {
-      await ctx[Symbol.asyncDispose]();
-    } finally {
-      mcpServerInitialized = false;
-    }
+    await ctx[Symbol.asyncDispose]();
   };
-  mcpServerInitialized = true;
   return handle;
 }

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -1,7 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CORE_SERVER_INSTRUCTIONS, SERVER_NAME, SERVER_VERSION } from '../constants.js';
 import type { ServerConfig } from './config.js';
-import { PineconeClient } from './pinecone-client.js';
 import {
   createServer,
   getDefaultServerContext,

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -102,12 +102,8 @@ function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
       );
     }
 
-    let existingClient: PineconeClient | undefined;
-    try {
-      existingClient = getDefaultServerContext().getClientIfSet();
-    } catch {
-      existingClient = undefined;
-    }
+    const defaultCtx = getDefaultServerContext();
+    const existingClient = defaultCtx.hasInjectedClient() ? defaultCtx.getClientIfSet() : undefined;
     const ctx = createServer(opts.config);
     if (existingClient) {
       ctx.setClient(existingClient);

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -53,7 +53,15 @@ function isServerConfig(value: unknown): value is ServerConfig {
 }
 
 function isSetupCoreServerOptions(value: unknown): value is SetupCoreServerOptions {
-  return typeof value === 'object' && value !== null && !isServerConfig(value);
+  if (typeof value !== 'object' || value === null || isServerConfig(value)) {
+    return false;
+  }
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    if (key !== 'config' && key !== 'context' && key !== 'instructions') {
+      return false;
+    }
+  }
+  return true;
 }
 
 function normalizeSetupCoreServerArgs(
@@ -69,12 +77,18 @@ function normalizeSetupCoreServerArgs(
   if (isSetupCoreServerOptions(configOrOptions)) {
     return { ...configOrOptions, ...legacyOptions };
   }
-  return legacyOptions ?? {};
+  throw new TypeError('configOrOptions must be a ServerConfig or SetupCoreServerOptions');
 }
 
 function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
   if (opts.context) {
     if (opts.config) {
+      if (opts.context.hasInjectedClient()) {
+        throw new Error(
+          'Passing both config and context clears an injected Pinecone client. ' +
+            'Omit config when reusing a pre-configured context, or call setClient() after setup.'
+        );
+      }
       opts.context.setConfig(opts.config);
     }
     return opts.context;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@
 /**
  * Pinecone Read-Only MCP CLI entry point.
  *
- * Thin composition root: parseCli() -> resolveAllianceConfig() -> setupAllianceServer(config)
- * -> connect to stdio transport.
+ * Thin composition root: parseCli() -> resolveAllianceConfig() -> createServer(config)
+ * -> ctx.setClient(...) -> setupAllianceServer({ config, context: ctx }) -> connect to stdio transport.
  */
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -13,7 +13,7 @@ import { parseCli, printHelp, printVersion } from './cli.js';
 import type { ServerConfig } from './core/config.js';
 import { resolveAllianceConfig } from './alliance/config.js';
 import { PineconeClient } from './core/pinecone-client.js';
-import { setPineconeClient } from './core/server/client-context.js';
+import { createServer } from './core/server/server-context.js';
 import { setupAllianceServer } from './alliance/setup.js';
 import { setLogFormat, setLogLevel, warn as logWarn } from './logger.js';
 
@@ -64,7 +64,8 @@ async function main(): Promise<void> {
       defaultTopK: config.defaultTopK,
       requestTimeoutMs: config.requestTimeoutMs,
     });
-    setPineconeClient(client);
+    const ctx = createServer(config);
+    ctx.setClient(client);
 
     if (config.checkIndexes) {
       const result = await client.checkIndexes();
@@ -88,7 +89,7 @@ async function main(): Promise<void> {
     }
     process.stderr.write(`Log level: ${config.logLevel} (format: ${config.logFormat})\n`);
 
-    const server = await setupAllianceServer(config);
+    const server = await setupAllianceServer({ config, context: ctx });
     const transport = new StdioServerTransport();
     await server.connect(transport);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * Pinecone Read-Only MCP CLI entry point.
  *
  * Thin composition root: parseCli() -> resolveAllianceConfig() -> createServer(config)
- * -> ctx.setClient(...) -> setupAllianceServer({ config, context: ctx }) -> connect to stdio transport.
+ * -> ctx.setClient(...) -> setupAllianceServer({ context: ctx }) -> connect to stdio transport.
  */
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -89,7 +89,7 @@ async function main(): Promise<void> {
     }
     process.stderr.write(`Log level: ${config.logLevel} (format: ${config.logFormat})\n`);
 
-    const server = await setupAllianceServer({ config, context: ctx });
+    const server = await setupAllianceServer({ context: ctx });
     const transport = new StdioServerTransport();
     await server.connect(transport);
 


### PR DESCRIPTION
## Summary

setup now accepts `{ config?, context?, instructions? }` so multiple isolated `ServerContext` instances can register tools in one process. The process-global `mcpServerInitialized` guard is replaced with per-context registration tracking; legacy positional `setupCoreServer(config)` and `teardownServer()` remain supported.

## Changes

- `setupCoreServer` / `setupAllianceServer` — options object + backward-compatible positional overloads
- `ServerContext` — `toolsRegistered` guard (`assertCanRegisterTools`, `markToolsRegistered`); legacy double-setup still throws via `peekDefaultServerContext()`
- Explicit `context` at setup preserves `ctx.setClient(...)` without pulling from the process default
- Alliance tools and builtins bind to the same `ctx` passed to core setup
- CLI: `createServer(config)` → `ctx.setClient(...)` → `setupAllianceServer({ config, context: ctx })`
- Docs/examples: instance-first embedder recipe in README, MIGRATION.md, CONFIGURATION.md, `library-embedding-demo.ts`
- New `setup-multi-instance.test.ts` — coexistence, URL/suggest-flow/cache isolation, injected client, `await using`

## Acceptance criteria

- [x] `setupCoreServer({ config?, context?, instructions? })`
- [x] `setupAllianceServer({ config?, context?, instructions? })` — same ctx for core + Alliance
- [x] Per-context init guard; different contexts can setup without `teardownServer()`
- [x] Injected client preserved when `context` is provided
- [x] `teardownServer()` valid for legacy single-server flows (documented)
- [x] CLI + library-embedding-demo + README/MIGRATION recipes updated
- [x] Multi-instance integration tests; legacy setup tests unchanged

## Test plan

- [x] `npm test` — 245 tests pass
- [x] `npm run build` — pass
- [x] `setup-multi-instance.test.ts` — multi-setup, isolation, injected client, `await using`
- [x] `server.test.ts` / `lifecycle.context.test.ts` — legacy positional setup + `teardownServer` path
- [ ] CI green on PR

## Notes for reviewers

- Legacy path without explicit `context` still uses `createServer` + client transfer from `setPineconeClient`; Alliance delegates that to `setupCoreServer` when `context` is omitted.
- Passing both `config` and `context` calls `setConfig`, which clears an injected client — embedders should omit `config` when the context is already configured.

## Related Issue
- Close https://github.com/cppalliance/pinecone-read-only-mcp-typescript/issues/141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised README, configuration, and migration docs to describe instance-first embedding and context-based setup, with updated examples and teardown guidance.

* **New Features**
  * Per-context server instances with isolated clients, URL generators, namespaces cache, and suggest-flow state; explicit lifecycle/teardown support.

* **Tests**
  * New multi-instance test suite validating isolation, client preservation, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->