### PR TITLE
Bugfix/legacy facade dual state and v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Tagged releases are published to npm from GitHub Actions when a **GitHub Release
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-23
+
 ### Added
 
 - `guided_query` tool registered by `setupCoreServer` / package-root import (core-layer handler; no Alliance URL generators or index defaults required).
@@ -29,18 +31,16 @@ Tagged releases are published to npm from GitHub Actions when a **GitHub Release
 
 ### Deprecated
 
-- Module-level singleton facades — use `ServerContext` instance methods via `createServer(config)` and `{ context: ctx }` at setup instead. Deprecated in the **next minor release** (see `[Unreleased]` until version is tagged); earliest removal **two minor releases later** per [deprecation-policy.md](docs/deprecation-policy.md#deprecation-window). Affected symbols: `getPineconeClient`, `setPineconeClient`, `clearPineconeClient`, `getServerConfig`, `setServerConfig`, `resetServerConfig`, `registerUrlGenerator`, `unregisterUrlGenerator`, `generateUrlForNamespace`, `hasUrlGenerator`, `resetUrlGenerationRegistry`, `markSuggested`, `requireSuggested`, `resetSuggestionFlow`, `getNamespacesWithCache`, `invalidateNamespacesCache`, `getDefaultServerContext`. See [MIGRATION.md § Legacy module-facade deprecations](docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations) and [deprecation-policy.md](docs/deprecation-policy.md#active-deprecations-legacy-module-facades).
-
-### Added
-
-- Zod schemas for all nine MCP tool success responses (`queryResponseSchema`, `guidedQueryResponseSchema`, etc.) exported from the package root for client-side validation. Success payloads are runtime-validated before return.
-- Stable vs experimental response field taxonomy documented in [docs/TOOLS.md](docs/TOOLS.md) and [docs/deprecation-policy.md](docs/deprecation-policy.md#stable-vs-experimental-mcp-response-fields).
-- Formal deprecation policy ([docs/deprecation-policy.md](docs/deprecation-policy.md)) and breaking-change release notes template ([docs/templates/breaking-change-release-notes.md](docs/templates/breaking-change-release-notes.md)).
+- Module-level singleton facades — use `ServerContext` instance methods via `createServer(config)` and `{ context: ctx }` at setup instead. Deprecated in **0.3.0**; earliest removal **0.5.0** per [deprecation-policy.md](docs/deprecation-policy.md#deprecation-window). Affected symbols: `getPineconeClient`, `setPineconeClient`, `clearPineconeClient`, `getServerConfig`, `setServerConfig`, `resetServerConfig`, `registerUrlGenerator`, `unregisterUrlGenerator`, `generateUrlForNamespace`, `hasUrlGenerator`, `resetUrlGenerationRegistry`, `markSuggested`, `requireSuggested`, `resetSuggestionFlow`, `getNamespacesWithCache`, `invalidateNamespacesCache`, `getDefaultServerContext`. Opt-in runtime warnings when `PINECONE_DEPRECATION_WARNINGS=1` or log level is `DEBUG`. See [MIGRATION.md § Legacy module-facade deprecations](docs/MIGRATION.md#030-legacy-module-facade-deprecations) and [deprecation-policy.md](docs/deprecation-policy.md#active-deprecations-legacy-module-facades).
 
 ### Removed
 
 - **Breaking (library):** `buildQueryExperimental` and `buildGuidedQueryExperimental` are no longer re-exported from `@will-cppa/pinecone-read-only-mcp` or `@will-cppa/pinecone-read-only-mcp/alliance`. They were internal helpers used to assemble the `experimental` block on `query` / `query_documents` / `guided_query` success payloads. The assembled fields and Zod schemas (`queryResponseSchema`, `QueryExperimental`, etc.) are unchanged — see [Unreleased stable vs experimental](docs/MIGRATION.md#unreleased-stable-vs-experimental-response-fields).
 - **No change:** `HybridQueryResult`, `HybridLegFailed`, and `KeywordIndexNamespacesResult` remain exported as the declared return types of public `PineconeClient` methods.
+
+### Fixed
+
+- Legacy module facades no longer silently diverge from an explicit `ServerContext` passed to `setupCoreServer` / `setupAllianceServer`. Mixing legacy facades with `{ context: ctx }` setup now throws with migration guidance instead of dual-state behavior.
 
 ## [0.2.0] - 2026-05-29
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ const server = await setupAllianceServer(resolveAllianceConfig({ apiKey: '...' }
 // Call teardownServer() before re-initializing the process-default context.
 ```
 
-Do not use this pattern for new code or multi-tenant embedding. See [docs/MIGRATION.md](docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations).
+Do not use this pattern for new code or multi-tenant embedding. See [docs/MIGRATION.md](docs/MIGRATION.md#030-legacy-module-facade-deprecations).
 
 ### Custom URL generators
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -69,9 +69,9 @@ When no experimental fields apply, the `experimental` key is **omitted** (not an
 
 **Promotion:** Moving a field from `experimental` to stable requires CHANGELOG, TOOLS.md, and schema updates per [deprecation-policy.md § Stable vs experimental](./deprecation-policy.md#stable-vs-experimental-mcp-response-fields).
 
-## Unreleased: Legacy module-facade deprecations
+## 0.3.0: Legacy module-facade deprecations
 
-**Rationale:** Module-level singleton facades (`setPineconeClient`, `registerUrlGenerator`, `getDefaultServerContext`, etc.) delegate to a process-global `ServerContext`. They complicate multi-tenant embedding and hide initialization order. They are marked `@deprecated` in JSDoc; earliest removal is **two minor releases after** the deprecation minor (see [deprecation-policy.md § Deprecation window](./deprecation-policy.md#deprecation-window)).
+**Rationale:** Module-level singleton facades (`setPineconeClient`, `registerUrlGenerator`, `getDefaultServerContext`, etc.) delegate to a process-global `ServerContext`. They complicate multi-tenant embedding and hide initialization order. They are marked `@deprecated` in JSDoc since **0.3.0**; earliest removal is **0.5.0** (see [deprecation-policy.md § Deprecation window](./deprecation-policy.md#deprecation-window)).
 
 **Who is affected:** Library embedders importing facade functions from `@will-cppa/pinecone-read-only-mcp` or `/alliance`.
 
@@ -184,7 +184,7 @@ import { buildQueryExperimental } from '@will-cppa/pinecone-read-only-mcp';
 
 ## Unreleased: `ServerContext` instance APIs (initial)
 
-**Rationale:** Process-global singletons (Pinecone client slot, config, URL registry, suggest-flow gate, namespaces cache) complicate testing and multi-tenant embedding. The initial milestone introduces an opt-in **`ServerContext`**; legacy module facades are deprecated (see [Legacy module-facade deprecations](#unreleased-legacy-module-facade-deprecations)).
+**Rationale:** Process-global singletons (Pinecone client slot, config, URL registry, suggest-flow gate, namespaces cache) complicate testing and multi-tenant embedding. The initial milestone introduces an opt-in **`ServerContext`**; legacy module facades are deprecated since **0.3.0** (see [Legacy module-facade deprecations](#030-legacy-module-facade-deprecations)).
 
 **Deprecated (migrate before removal):**
 

--- a/docs/deprecation-policy.md
+++ b/docs/deprecation-policy.md
@@ -34,16 +34,16 @@ APIs deprecated **before** this policy was published follow the removal target r
 
 ### Active deprecations - legacy module facades
 
-Module-level singleton facades delegate to `getDefaultServerContext()`. Migrate to **`ServerContext`** instance methods via `createServer(config)` and pass `{ context: ctx }` to `setupCoreServer` / `setupAllianceServer`. Deprecated in the **next published minor** after merge; earliest removal **two minor releases later** (per [Deprecation window](#deprecation-window) above). See [MIGRATION.md § Legacy module-facade deprecations](./MIGRATION.md#unreleased-legacy-module-facade-deprecations).
+Module-level singleton facades delegate to `getDefaultServerContext()`. Migrate to **`ServerContext`** instance methods via `createServer(config)` and pass `{ context: ctx }` to `setupCoreServer` / `setupAllianceServer`. Deprecated in **`0.3.0`**; earliest removal **`0.5.0`** (per [Deprecation window](#deprecation-window) above). See [MIGRATION.md § Legacy module-facade deprecations](./MIGRATION.md#030-legacy-module-facade-deprecations).
 
 | Facade | Layer | Replacement | Deprecated in | Earliest removal |
 | ------ | ----- | ----------- | ------------- | ---------------- |
-| `getPineconeClient` / `setPineconeClient` / `clearPineconeClient` | core | `ctx.getClient()` / `ctx.setClient()` / `ctx.clearClient()` | next minor (TBD at release) | two minors after deprecation minor |
-| `getServerConfig` / `setServerConfig` / `resetServerConfig` | core | `ctx.getConfig()` / `ctx.setConfig()` / `ctx.teardown()` | next minor (TBD at release) | two minors after deprecation minor |
-| `registerUrlGenerator` / `unregisterUrlGenerator` / `generateUrlForNamespace` / `hasUrlGenerator` / `resetUrlGenerationRegistry` | core | `ctx.registerUrlGenerator()` etc. / `ctx.resetUrlGenerators()` | next minor (TBD at release) | two minors after deprecation minor |
-| `markSuggested` / `requireSuggested` / `resetSuggestionFlow` | core | `ctx.markSuggested()` / `ctx.requireSuggested()` / `ctx.resetSuggestionFlow()` | next minor (TBD at release) | two minors after deprecation minor |
-| `getNamespacesWithCache` / `invalidateNamespacesCache` | core | `ctx.getNamespacesWithCache()` / `ctx.invalidateNamespacesCache()` | next minor (TBD at release) | two minors after deprecation minor |
-| `getDefaultServerContext` | core | Return value of `createServer` or explicit `context` at setup | next minor (TBD at release) | two minors after deprecation minor |
+| `getPineconeClient` / `setPineconeClient` / `clearPineconeClient` | core | `ctx.getClient()` / `ctx.setClient()` / `ctx.clearClient()` | **0.3.0** | **0.5.0** |
+| `getServerConfig` / `setServerConfig` / `resetServerConfig` | core | `ctx.getConfig()` / `ctx.setConfig()` / `ctx.teardown()` | **0.3.0** | **0.5.0** |
+| `registerUrlGenerator` / `unregisterUrlGenerator` / `generateUrlForNamespace` / `hasUrlGenerator` / `resetUrlGenerationRegistry` | core | `ctx.registerUrlGenerator()` etc. / `ctx.resetUrlGenerators()` | **0.3.0** | **0.5.0** |
+| `markSuggested` / `requireSuggested` / `resetSuggestionFlow` | core | `ctx.markSuggested()` / `ctx.requireSuggested()` / `ctx.resetSuggestionFlow()` | **0.3.0** | **0.5.0** |
+| `getNamespacesWithCache` / `invalidateNamespacesCache` | core | `ctx.getNamespacesWithCache()` / `ctx.invalidateNamespacesCache()` | **0.3.0** | **0.5.0** |
+| `getDefaultServerContext` | core | Return value of `createServer` or explicit `context` at setup | **0.3.0** | **0.5.0** |
 
 `teardownServer()` remains supported during the deprecation window; prefer `ctx.teardown()` or `await using` on the setup handle. Documented in MIGRATION.md; not marked `@deprecated` until a later release.
 
@@ -110,7 +110,7 @@ New response fields added before `1.0.0` default to `experimental` unless explic
 
 Legacy module-level facades are deprecated per the [active deprecations table](./deprecation-policy.md#active-deprecations-legacy-module-facades) above. `ServerContext` + `createServer` / setup APIs are the supported public contract going forward.
 
-See [MIGRATION.md § Legacy module-facade deprecations](./MIGRATION.md#unreleased-legacy-module-facade-deprecations) for before/after embedder snippets.
+See [MIGRATION.md § Legacy module-facade deprecations](./MIGRATION.md#030-legacy-module-facade-deprecations) for before/after embedder snippets.
 
 ## CHANGELOG format for breaking changes
 

--- a/examples/alliance/library-embedding-demo.ts
+++ b/examples/alliance/library-embedding-demo.ts
@@ -16,7 +16,7 @@
  *
  * **Legacy (deprecated):** `setPineconeClient(client)` then
  * `await setupAllianceServer(config)` still works during the deprecation window;
- * see [docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations](docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations).
+ * see [docs/MIGRATION.md#030-legacy-module-facade-deprecations](docs/MIGRATION.md#030-legacy-module-facade-deprecations).
  */
 
 import { createServer, PineconeClient } from '@will-cppa/pinecone-read-only-mcp';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@will-cppa/pinecone-read-only-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A Model Context Protocol (MCP) server that provides semantic search over Pinecone vector databases using hybrid search (dense + sparse) with reranking.",
   "type": "module",
   "main": "dist/core/index.js",

--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -1,6 +1,6 @@
 import { ALLIANCE_SERVER_INSTRUCTIONS } from '../constants.js';
 import type { ServerConfig } from '../core/config.js';
-import { getDefaultServerContext, type ServerContext } from '../core/server/server-context.js';
+import { resolveDefaultServerContext, type ServerContext } from '../core/server/server-context.js';
 import { resolveAllianceConfig } from './config.js';
 import { setupCoreServer, type ServerHandle, type SetupCoreServerOptions } from '../core/setup.js';
 import { registerBuiltinUrlGenerators } from './url-builtins.js';
@@ -82,7 +82,7 @@ export async function setupAllianceServer(
       config: opts.config ?? config,
       instructions,
     });
-    resolvedCtx = getDefaultServerContext();
+    resolvedCtx = resolveDefaultServerContext();
   }
 
   registerBuiltinUrlGenerators(resolvedCtx);

--- a/src/core/server/client-context.ts
+++ b/src/core/server/client-context.ts
@@ -1,41 +1,42 @@
 import { PineconeClient } from '../pinecone-client.js';
-import { getDefaultServerContext } from './server-context.js';
+import { warnLegacyFacade } from './legacy-facade-warn.js';
+import { resolveDefaultServerContext } from './server-context.js';
 
 /**
  * Return the shared Pinecone client; throws if setPineconeClient has not been called.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.getClient} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.getClient} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.getClient
  */
 export function getPineconeClient(): PineconeClient {
-  return getDefaultServerContext().getClientIfSet();
+  warnLegacyFacade('getPineconeClient');
+  return resolveDefaultServerContext().getClientIfSet();
 }
 
 /**
  * Set the shared Pinecone client used by all MCP tools.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.setClient} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.setClient} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.setClient
  */
 export function setPineconeClient(client: PineconeClient): void {
-  getDefaultServerContext().setClient(client);
+  warnLegacyFacade('setPineconeClient');
+  resolveDefaultServerContext().setClient(client);
 }
 
 /**
  * Clear the shared client (used by {@link teardownServer} and tests).
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.clearClient} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.clearClient} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.clearClient
  */
 export function clearPineconeClient(): void {
-  getDefaultServerContext().clearClient();
+  warnLegacyFacade('clearPineconeClient');
+  resolveDefaultServerContext().clearClient();
 }

--- a/src/core/server/config-context.ts
+++ b/src/core/server/config-context.ts
@@ -1,6 +1,7 @@
 import type { ServerConfig } from '../config.js';
+import { warnLegacyFacade } from './legacy-facade-warn.js';
 import {
-  getDefaultServerContext,
+  resolveDefaultServerContext,
   setDefaultServerContext,
   setPendingServerConfig,
 } from './server-context.js';
@@ -8,26 +9,26 @@ import {
 /**
  * Replace the process-global server config (called from setup with CLI/env-derived config).
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.setConfig} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.setConfig} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.setConfig
  */
 export function setServerConfig(config: ServerConfig): void {
+  warnLegacyFacade('setServerConfig');
   setPendingServerConfig(config);
 }
 
 /**
  * Clear active config so the next `getServerConfig()` resolves again (used by {@link teardownServer}).
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.teardown} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.teardown} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.teardown
  */
 export function resetServerConfig(): void {
+  warnLegacyFacade('resetServerConfig');
   setDefaultServerContext(null);
 }
 
@@ -39,12 +40,12 @@ export function resetServerConfig(): void {
  * (requires `PINECONE_API_KEY` and `PINECONE_INDEX_NAME` or throws). Alliance apps should
  * pass config from `resolveAllianceConfig()` into `setupAllianceServer(config)`.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.getConfig} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.getConfig} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.getConfig
  */
 export function getServerConfig(): ServerConfig {
-  return getDefaultServerContext().getConfig();
+  warnLegacyFacade('getServerConfig');
+  return resolveDefaultServerContext().getConfig();
 }

--- a/src/core/server/legacy-facade-warn.test.ts
+++ b/src/core/server/legacy-facade-warn.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setLogLevel } from '../../logger.js';
+import { setPineconeClient } from './client-context.js';
+import { resetLegacyFacadeWarnLatchForTests, warnLegacyFacade } from './legacy-facade-warn.js';
+import { teardownDefaultServerContext } from './server-context.js';
+
+describe('legacy-facade-warn', () => {
+  const originalEnv = process.env['PINECONE_DEPRECATION_WARNINGS'];
+
+  beforeEach(() => {
+    resetLegacyFacadeWarnLatchForTests();
+    setLogLevel('INFO');
+    delete process.env['PINECONE_DEPRECATION_WARNINGS'];
+    teardownDefaultServerContext();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env['PINECONE_DEPRECATION_WARNINGS'];
+    } else {
+      process.env['PINECONE_DEPRECATION_WARNINGS'] = originalEnv;
+    }
+    resetLegacyFacadeWarnLatchForTests();
+    setLogLevel('INFO');
+    teardownDefaultServerContext();
+  });
+
+  it('does not warn by default', () => {
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnLegacyFacade('getPineconeClient');
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('warns once per symbol when PINECONE_DEPRECATION_WARNINGS=1', () => {
+    process.env['PINECONE_DEPRECATION_WARNINGS'] = '1';
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    warnLegacyFacade('setPineconeClient');
+    warnLegacyFacade('setPineconeClient');
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(String(warnSpy.mock.calls[0]?.[0])).toMatch(/setPineconeClient is deprecated/);
+    warnSpy.mockRestore();
+  });
+
+  it('warns when log level is DEBUG', () => {
+    setLogLevel('DEBUG');
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    warnLegacyFacade('getDefaultServerContext');
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    warnSpy.mockRestore();
+  });
+
+  it('setPineconeClient warns once through facade when env enabled', () => {
+    process.env['PINECONE_DEPRECATION_WARNINGS'] = '1';
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    setPineconeClient({ query: vi.fn() } as never);
+    setPineconeClient({ query: vi.fn() } as never);
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(String(warnSpy.mock.calls[0]?.[0])).toMatch(/setPineconeClient is deprecated/);
+    warnSpy.mockRestore();
+  });
+});

--- a/src/core/server/legacy-facade-warn.ts
+++ b/src/core/server/legacy-facade-warn.ts
@@ -1,0 +1,25 @@
+import { getLogLevel, warn as logWarn } from '../../logger.js';
+
+const warnedSymbols = new Set<string>();
+
+function deprecationWarningsEnabled(): boolean {
+  return process.env['PINECONE_DEPRECATION_WARNINGS'] === '1' || getLogLevel() === 'DEBUG';
+}
+
+/** Emit at most one opt-in deprecation warning per legacy facade symbol per process. */
+export function warnLegacyFacade(symbol: string): void {
+  if (!deprecationWarningsEnabled() || warnedSymbols.has(symbol)) {
+    return;
+  }
+  warnedSymbols.add(symbol);
+  logWarn(
+    `${symbol} is deprecated (since 0.3.0) and will be removed no earlier than 0.5.0; ` +
+      'use ServerContext instance methods via createServer and { context: ctx } at setup. ' +
+      'See docs/MIGRATION.md#030-legacy-module-facade-deprecations.'
+  );
+}
+
+/** Reset per-symbol deprecation latch. Test-only. */
+export function resetLegacyFacadeWarnLatchForTests(): void {
+  warnedSymbols.clear();
+}

--- a/src/core/server/namespaces-cache.ts
+++ b/src/core/server/namespaces-cache.ts
@@ -1,4 +1,5 @@
-import { getDefaultServerContext, type NamespaceInfo } from './server-context.js';
+import { warnLegacyFacade } from './legacy-facade-warn.js';
+import { resolveDefaultServerContext, type NamespaceInfo } from './server-context.js';
 
 export type { NamespaceInfo };
 
@@ -6,10 +7,9 @@ export type { NamespaceInfo };
  * Return namespace list with metadata; uses an in-memory cache whose TTL is
  * sourced from the active `ServerConfig.cacheTtlMs`.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.getNamespacesWithCache} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.getNamespacesWithCache} on a {@link ServerContext} from
+ * {@link createServer} instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.getNamespacesWithCache
  */
 export async function getNamespacesWithCache(): Promise<{
@@ -17,18 +17,19 @@ export async function getNamespacesWithCache(): Promise<{
   cache_hit: boolean;
   expires_at: number;
 }> {
-  return getDefaultServerContext().getNamespacesWithCache();
+  warnLegacyFacade('getNamespacesWithCache');
+  return resolveDefaultServerContext().getNamespacesWithCache();
 }
 
 /**
  * Clear the namespaces cache so the next call to getNamespacesWithCache refetches.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.invalidateNamespacesCache} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.invalidateNamespacesCache} on a {@link ServerContext} from
+ * {@link createServer} instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.invalidateNamespacesCache
  */
 export function invalidateNamespacesCache(): void {
-  getDefaultServerContext().invalidateNamespacesCache();
+  warnLegacyFacade('invalidateNamespacesCache');
+  resolveDefaultServerContext().invalidateNamespacesCache();
 }

--- a/src/core/server/server-context.legacy-facade.test.ts
+++ b/src/core/server/server-context.legacy-facade.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setupAllianceServer } from '../../alliance/setup.js';
+import { setPineconeClient, setupCoreServer, teardownServer } from '../index.js';
+import { getPineconeClient } from './client-context.js';
+import { createIsolatedContext, createServer, getDefaultServerContext } from './server-context.js';
+import {
+  createTestServerContext,
+  isolateFromDefaultContext,
+  resolveTestConfig,
+} from './tools/test-helpers.js';
+
+describe('legacy facade vs explicit setup context', () => {
+  afterEach(() => {
+    teardownServer();
+    isolateFromDefaultContext();
+  });
+
+  it('legacy then setup with config keeps getPineconeClient consistent with default context', async () => {
+    isolateFromDefaultContext();
+    const injected = { query: vi.fn() };
+    const cfg = resolveTestConfig({ apiKey: 'legacy-config', indexName: 'idx-config' });
+    setPineconeClient(injected as never);
+
+    await setupCoreServer(cfg);
+
+    expect(getPineconeClient()).toBe(injected);
+    expect(getDefaultServerContext().getClient()).toBe(injected);
+  });
+
+  it('legacy then setup with explicit context throws on getPineconeClient', async () => {
+    isolateFromDefaultContext();
+    const injected = { query: vi.fn() };
+    setPineconeClient(injected as never);
+    const isolatedCtx = createTestServerContext({
+      config: resolveTestConfig({ apiKey: 'isolated', indexName: 'idx-iso' }),
+      client: { query: vi.fn() } as never,
+    });
+
+    await setupCoreServer({ context: isolatedCtx });
+
+    expect(() => getPineconeClient()).toThrow(/Legacy module facades are unavailable/);
+    expect(() => getDefaultServerContext()).toThrow(/Legacy module facades are unavailable/);
+    expect(isolatedCtx.hasToolsRegistered()).toBe(true);
+  });
+
+  it('setupAllianceServer with explicit context throws on legacy facade use', async () => {
+    isolateFromDefaultContext();
+    setPineconeClient({ query: vi.fn() } as never);
+    const isolatedCtx = createTestServerContext({
+      config: resolveTestConfig({ disableSuggestFlow: false }),
+      client: { query: vi.fn() } as never,
+    });
+
+    await setupAllianceServer({ context: isolatedCtx });
+
+    expect(() => getPineconeClient()).toThrow(/Legacy module facades are unavailable/);
+  });
+
+  it('instance-only setup with createServer context does not require legacy facades', async () => {
+    isolateFromDefaultContext();
+    const cfg = resolveTestConfig({ apiKey: 'instance-only', indexName: 'idx-io' });
+    const ctx = createServer(cfg, { client: { query: vi.fn() } as never });
+
+    await setupCoreServer({ context: ctx });
+
+    expect(ctx.hasToolsRegistered()).toBe(true);
+    expect(ctx.getClient()).toBeDefined();
+  });
+
+  it('createIsolatedContext setup without prior legacy use allows lazy default until facade call', async () => {
+    isolateFromDefaultContext();
+    const isolatedCtx = createIsolatedContext(resolveTestConfig({ apiKey: 'pure-iso' }), {
+      client: { query: vi.fn() } as never,
+    });
+
+    await setupCoreServer({ context: isolatedCtx });
+
+    expect(isolatedCtx.hasToolsRegistered()).toBe(true);
+    expect(() => getPineconeClient()).toThrow(/Legacy module facades are unavailable/);
+  });
+
+  it('teardownServer after supersede restores legacy facade path', async () => {
+    isolateFromDefaultContext();
+    setPineconeClient({ query: vi.fn() } as never);
+    const isolatedCtx = createTestServerContext({ client: { query: vi.fn() } as never });
+
+    await setupCoreServer({ context: isolatedCtx });
+    expect(() => getPineconeClient()).toThrow(/Legacy module facades are unavailable/);
+
+    teardownServer();
+
+    const reinjected = { query: vi.fn() };
+    setPineconeClient(reinjected as never);
+    expect(getPineconeClient()).toBe(reinjected);
+  });
+});

--- a/src/core/server/server-context.ts
+++ b/src/core/server/server-context.ts
@@ -1,6 +1,7 @@
 import type { ServerConfig } from '../config.js';
 import { resolveConfig } from '../config.js';
 import { PineconeClient } from '../pinecone-client.js';
+import { warnLegacyFacade } from './legacy-facade-warn.js';
 import { normalizeNamespace } from './namespace-utils.js';
 import type { RecommendedTool } from './query-suggestion.js';
 import type { UrlGenerationResult, UrlGeneratorFn } from './url-registry.js';
@@ -361,12 +362,21 @@ export class ServerContext implements AsyncDisposable {
       pendingConfig = null;
       pendingComposition = null;
     }
+    if (facadeSupersededBy === this) {
+      facadeSupersededBy = null;
+    }
   }
 }
 
 let defaultContext: ServerContext | null = null;
+let facadeSupersededBy: ServerContext | null = null;
 let pendingConfig: ServerConfig | null = null;
 let pendingComposition: ServerContextComposition | null = null;
+
+const LEGACY_FACADE_SUPERSEDED_MESSAGE =
+  'Legacy module facades are unavailable after setup with an explicit context. ' +
+  'Use methods on the ServerContext passed to setupCoreServer / setupAllianceServer. ' +
+  'See docs/MIGRATION.md#030-legacy-module-facade-deprecations.';
 
 /** Peek at the process-default context without materializing a new one. */
 export function peekDefaultServerContext(): ServerContext | null {
@@ -376,13 +386,21 @@ export function peekDefaultServerContext(): ServerContext | null {
 /**
  * Process-default context used by legacy module facades.
  *
- * @deprecated Legacy module facade. Pass a {@link ServerContext} from {@link createServer}
- * explicitly to setup APIs instead. Removal follows docs/deprecation-policy.md (no earlier
- * than two minor releases after the deprecation minor). See
- * docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Pass a
+ * {@link ServerContext} from {@link createServer} explicitly to setup APIs instead. See
+ * docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see createServer
  */
 export function getDefaultServerContext(): ServerContext {
+  warnLegacyFacade('getDefaultServerContext');
+  return resolveDefaultServerContext();
+}
+
+/** Resolve process-default context for internal setup and legacy facade delegation (no warning). */
+export function resolveDefaultServerContext(): ServerContext {
+  if (facadeSupersededBy !== null) {
+    throw new Error(LEGACY_FACADE_SUPERSEDED_MESSAGE);
+  }
   if (!defaultContext) {
     const cfg = pendingConfig ?? undefined;
     const comp = pendingComposition ?? undefined;
@@ -393,9 +411,24 @@ export function getDefaultServerContext(): ServerContext {
   return defaultContext;
 }
 
+/**
+ * Mark that setup runs on an explicit non-default context so legacy module facades fail fast.
+ * When {@link ctx} is the process default, legacy facades remain available.
+ */
+export function installExplicitServerContext(ctx: ServerContext): void {
+  if (defaultContext !== null && defaultContext !== ctx) {
+    defaultContext.teardown();
+    defaultContext = null;
+    pendingConfig = null;
+    pendingComposition = null;
+  }
+  facadeSupersededBy = defaultContext === ctx ? null : ctx;
+}
+
 /** Replace or clear the process-default context (tests and teardown). */
 export function setDefaultServerContext(ctx: ServerContext | null): void {
   defaultContext = ctx;
+  facadeSupersededBy = null;
   if (ctx === null) {
     pendingConfig = null;
     pendingComposition = null;
@@ -416,6 +449,7 @@ export function teardownDefaultServerContext(): void {
     defaultContext.teardown();
     defaultContext = null;
   }
+  facadeSupersededBy = null;
   pendingConfig = null;
   pendingComposition = null;
 }
@@ -435,6 +469,7 @@ export function createServer(
 ): ServerContext {
   const ctx = new ServerContext(config, composition);
   defaultContext = ctx;
+  facadeSupersededBy = null;
   pendingConfig = null;
   pendingComposition = null;
   return ctx;

--- a/src/core/server/suggestion-flow.ts
+++ b/src/core/server/suggestion-flow.ts
@@ -1,4 +1,5 @@
-import { getDefaultServerContext } from './server-context.js';
+import { warnLegacyFacade } from './legacy-facade-warn.js';
+import { resolveDefaultServerContext } from './server-context.js';
 import type { RecommendedTool } from './query-suggestion.js';
 
 type FlowState = {
@@ -11,14 +12,14 @@ type FlowState = {
 /**
  * Record that suggest_query_params was called for this namespace (enables query/count for the flow).
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.markSuggested} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.markSuggested} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.markSuggested
  */
 export function markSuggested(namespace: string, state: Omit<FlowState, 'updatedAt'>): void {
-  getDefaultServerContext().markSuggested(namespace, state);
+  warnLegacyFacade('markSuggested');
+  resolveDefaultServerContext().markSuggested(namespace, state);
 }
 
 /**
@@ -29,10 +30,9 @@ export function markSuggested(namespace: string, state: Omit<FlowState, 'updated
  * that always succeeds with an empty placeholder flow — operators that turn
  * the safety guard off accept the consequences.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.requireSuggested} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.requireSuggested} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.requireSuggested
  */
 export function requireSuggested(namespace: string):
@@ -44,18 +44,19 @@ export function requireSuggested(namespace: string):
       ok: false;
       message: string;
     } {
-  return getDefaultServerContext().requireSuggested(namespace);
+  warnLegacyFacade('requireSuggested');
+  return resolveDefaultServerContext().requireSuggested(namespace);
 }
 
 /**
  * Clear suggest-flow gate state (used by {@link teardownServer} and tests).
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.resetSuggestionFlow} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.resetSuggestionFlow} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.resetSuggestionFlow
  */
 export function resetSuggestionFlow(): void {
-  getDefaultServerContext().resetSuggestionFlow();
+  warnLegacyFacade('resetSuggestionFlow');
+  resolveDefaultServerContext().resetSuggestionFlow();
 }

--- a/src/core/server/url-registry.ts
+++ b/src/core/server/url-registry.ts
@@ -5,7 +5,8 @@
  * Library consumers can plug in their own with `registerUrlGenerator(namespace, generator)`.
  */
 
-import { getDefaultServerContext } from './server-context.js';
+import { warnLegacyFacade } from './legacy-facade-warn.js';
+import { resolveDefaultServerContext } from './server-context.js';
 
 /** Outcome of a URL-generation attempt. */
 export type UrlGenerationResult = {
@@ -39,14 +40,14 @@ export type UrlGeneratorFn = UrlGenerator;
  * Clear all URL generators.
  * Used by {@link teardownServer} so a subsequent setup can reinstall generators.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.resetUrlGenerators} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.resetUrlGenerators} on a {@link ServerContext} from
+ * {@link createServer} instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.resetUrlGenerators
  */
 export function resetUrlGenerationRegistry(): void {
-  getDefaultServerContext().resetUrlGenerators();
+  warnLegacyFacade('resetUrlGenerationRegistry');
+  resolveDefaultServerContext().resetUrlGenerators();
 }
 
 /**
@@ -54,55 +55,55 @@ export function resetUrlGenerationRegistry(): void {
  *
  * @param namespace exact namespace name (matches the value returned by `list_namespaces`).
  * @param generator function that turns a record's metadata into a URL ({@link UrlGeneratorFn}).
- * @deprecated Legacy module facade. Use {@link ServerContext.registerUrlGenerator} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.registerUrlGenerator} on a {@link ServerContext} from
+ * {@link createServer} instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.registerUrlGenerator
  */
 export function registerUrlGenerator(namespace: string, generator: UrlGeneratorFn): void {
-  getDefaultServerContext().registerUrlGenerator(namespace, generator);
+  warnLegacyFacade('registerUrlGenerator');
+  resolveDefaultServerContext().registerUrlGenerator(namespace, generator);
 }
 
 /**
  * Remove a namespace's URL generator. Returns true if a generator was removed.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.unregisterUrlGenerator} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.unregisterUrlGenerator} on a {@link ServerContext} from
+ * {@link createServer} instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.unregisterUrlGenerator
  */
 export function unregisterUrlGenerator(namespace: string): boolean {
-  return getDefaultServerContext().unregisterUrlGenerator(namespace);
+  warnLegacyFacade('unregisterUrlGenerator');
+  return resolveDefaultServerContext().unregisterUrlGenerator(namespace);
 }
 
 /**
  * True when the namespace has a registered URL generator (does not consider `metadata.url`).
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.hasUrlGenerator} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.hasUrlGenerator} on a {@link ServerContext} from {@link createServer}
+ * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.hasUrlGenerator
  */
 export function hasUrlGenerator(namespace: string): boolean {
-  return getDefaultServerContext().hasUrlGenerator(namespace);
+  warnLegacyFacade('hasUrlGenerator');
+  return resolveDefaultServerContext().hasUrlGenerator(namespace);
 }
 
 /**
  * Generate a URL for a record in the given namespace when metadata.url is missing.
  * Uses the registry of URL generators; returns unavailable for namespaces without a generator.
  *
- * @deprecated Legacy module facade. Use {@link ServerContext.generateUrlForNamespace} on a
- * {@link ServerContext} from {@link createServer} instead. Removal follows
- * docs/deprecation-policy.md (no earlier than two minor releases after the
- * deprecation minor). See docs/MIGRATION.md#unreleased-legacy-module-facade-deprecations.
+ * @deprecated since 0.3.0 — removal no earlier than 0.5.0. Legacy module facade. Use
+ * {@link ServerContext.generateUrlForNamespace} on a {@link ServerContext} from
+ * {@link createServer} instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.generateUrlForNamespace
  */
 export function generateUrlForNamespace(
   namespace: string,
   metadata: Record<string, unknown>
 ): UrlGenerationResult {
-  return getDefaultServerContext().generateUrlForNamespace(namespace, metadata);
+  warnLegacyFacade('generateUrlForNamespace');
+  return resolveDefaultServerContext().generateUrlForNamespace(namespace, metadata);
 }

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -3,8 +3,9 @@ import { CORE_SERVER_INSTRUCTIONS, SERVER_NAME, SERVER_VERSION } from '../consta
 import type { ServerConfig } from './config.js';
 import {
   createServer,
-  getDefaultServerContext,
+  installExplicitServerContext,
   peekDefaultServerContext,
+  resolveDefaultServerContext,
   teardownDefaultServerContext,
   type ServerContext,
 } from './server/server-context.js';
@@ -92,6 +93,7 @@ function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
       }
       opts.context.setConfig(opts.config);
     }
+    installExplicitServerContext(opts.context);
     return opts.context;
   }
 
@@ -103,7 +105,7 @@ function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
       );
     }
 
-    const defaultCtx = getDefaultServerContext();
+    const defaultCtx = resolveDefaultServerContext();
     const existingClient = defaultCtx.hasInjectedClient() ? defaultCtx.getClientIfSet() : undefined;
     const ctx = createServer(opts.config);
     if (existingClient) {
@@ -112,7 +114,7 @@ function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
     return ctx;
   }
 
-  return getDefaultServerContext();
+  return resolveDefaultServerContext();
 }
 
 export async function setupCoreServer(


### PR DESCRIPTION
## Summary

Fixes silent dual-state between legacy module facades and explicit `ServerContext` setup, and starts the legacy facade deprecation window on **v0.3.0**.

**#Issue 170: Dual-state fix**
- Adds `facadeSupersededBy` tracking and `installExplicitServerContext()` so `setupCoreServer({ context })` / `setupAllianceServer({ context })` on a non-default context invalidates legacy facades.
- `getDefaultServerContext()` throws with migration guidance when facades are superseded (no silent divergence between `getPineconeClient()` and `ctx.getClient()`).
- Client migration on the legacy `{ config }` setup path stays in `resolveSetupContext()`.
- Adds `resolveDefaultServerContext()` for internal/setup paths so deprecation warnings are not duplicated.

**Issue 171: v0.3.0 deprecation publish**
- Pins deprecation window: **deprecated 0.3.0**, **earliest removal 0.5.0** in `docs/deprecation-policy.md`, `docs/MIGRATION.md`, and `@deprecated` JSDoc across all 17 facade symbols.
- Moves accumulated `[Unreleased]` CHANGELOG content into `## [0.3.0]`.
- Adds opt-in runtime warnings via `PINECONE_DEPRECATION_WARNINGS=1` or `DEBUG` log level (once per symbol).
- Bumps `package.json` to **0.3.0**.

## Test plan

- [x] `setPineconeClient()` → `setupCoreServer(config)` → `getPineconeClient()` returns same client as default context
- [x] `setPineconeClient()` → `setupCoreServer({ context: isolatedCtx })` → `getPineconeClient()` throws with migration guidance
- [x] `setupAllianceServer({ context: isolatedCtx })` → legacy facade call throws
- [x] Instance-only: `createServer` + `setupCoreServer({ context })` registers tools on passed context
- [x] `teardownServer()` after supersede restores legacy facade path
- [x] `PINECONE_DEPRECATION_WARNINGS=1` warns once per symbol; default env produces no warn
- [x] `npm run ci` green
- [x] `npm run release:check` green
- [x] `npm run docs:link-check` green

## Release (post-merge)

After merge to `main`, create **GitHub Release `v0.3.0`** to trigger npm publish via CI (see `docs/RELEASING.md`).

## Related

- Close https://github.com/cppalliance/pinecone-read-only-mcp-typescript/issues/170
- Close https://github.com/cppalliance/pinecone-read-only-mcp-typescript/issues/171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified deprecation timeline for legacy module-level facades: deprecated in 0.3.0, with removal no earlier than 0.5.0.
  * Updated migration guide with deprecation details.

* **Bug Fixes**
  * Legacy module-level facades now emit deprecation warnings (opt-in via `PINECONE_DEPRECATION_WARNINGS` environment variable or debug logging).
  * Using legacy facades with an explicit ServerContext now throws an error with migration guidance instead of silently diverging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->