### PR TITLE
Add branded core and Alliance ServerConfig types

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -35,6 +35,7 @@ docs/
 
 # Testing
 coverage/
+dist/__tests__/
 
 # Logs
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Tagged releases are published to npm from GitHub Actions when a **GitHub Release
 
 ### Changed
 
-- **Library:** `resolveConfig()` returns `CoreServerConfig`; `resolveAllianceConfig()` returns `AllianceServerConfig`. `setupCoreServer` / `setupAllianceServer` accept only their respective branded config and context types (`CoreServerContext` / `AllianceServerContext`). `ServerConfig` remains an alias for `ServerConfigBase` on read paths (`ctx.getConfig()`). See [MIGRATION.md](docs/MIGRATION.md#unreleased-branded-server-config).
+- **Library:** `resolveConfig()` returns `CoreServerConfig`; `resolveAllianceConfig()` returns `AllianceServerConfig`. `setupCoreServer` / `setupAllianceServer` accept only their respective branded config and context types (`CoreServerContext` / `AllianceServerContext`). `ServerConfig` remains an alias for `ServerConfigBase` on read paths (`ctx.getConfig()`). See [MIGRATION.md](docs/MIGRATION.md#unreleased-branded-serverconfig-types).
 
 ## [0.3.0] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Tagged releases are published to npm from GitHub Actions when a **GitHub Release
 
 ## [Unreleased]
 
+### Changed
+
+- **Library:** `resolveConfig()` returns `CoreServerConfig`; `resolveAllianceConfig()` returns `AllianceServerConfig`. `setupCoreServer` / `setupAllianceServer` accept only their respective branded config and context types (`CoreServerContext` / `AllianceServerContext`). `ServerConfig` remains an alias for `ServerConfigBase` on read paths (`ctx.getConfig()`). See [MIGRATION.md](docs/MIGRATION.md#unreleased-branded-server-config).
+
 ## [0.3.0] - 2026-06-23
 
 ### Added

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -352,6 +352,37 @@ Core `resolveConfig` throws `Missing Pinecone index name: …` when the index is
 
 ---
 
+## Unreleased: Branded ServerConfig types
+
+**Rationale:** `resolveConfig()` and `resolveAllianceConfig()` produced structurally identical configs. Passing Alliance-resolved config or context into `setupCoreServer()` compiled but silently changed suggest-flow gate behavior (and related defaults).
+
+**Who is affected:** Library embedders typing resolver returns or setup arguments as `ServerConfig` instead of the branded types.
+
+**Migration:**
+
+Use branded resolver outputs with matching setup entry points and context factories:
+
+```typescript
+import { createServer, resolveConfig, setupCoreServer } from '@will-cppa/pinecone-read-only-mcp';
+import { resolveAllianceConfig, setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
+
+const coreCfg = resolveConfig({ apiKey, indexName });
+await setupCoreServer({ context: createServer(coreCfg) });
+
+const allianceCfg = resolveAllianceConfig({ apiKey });
+await setupAllianceServer({ context: createServer(allianceCfg) });
+```
+
+**Compile-time errors (intentional):**
+
+- `setupCoreServer(allianceCfg)` — Alliance config on core setup
+- `setupCoreServer({ context: createServer(allianceCfg) })` — Alliance context on core setup
+- `setupAllianceServer(coreCfg)` and `setupAllianceServer({ context: createServer(coreCfg) })` — symmetric misuse
+
+**Unchanged:** `ServerConfig` / `ServerConfigBase` remain valid for reading fields from `ctx.getConfig()` and other read-only config paths.
+
+---
+
 ## Migrating to v0.2.0
 
 ### Namespace trimming and suggest-flow

--- a/examples/alliance/custom-url-generator.ts
+++ b/examples/alliance/custom-url-generator.ts
@@ -17,10 +17,9 @@
 import {
   createServer,
   PineconeClient,
-  resolveConfig,
   type UrlGenerationResult,
 } from '@will-cppa/pinecone-read-only-mcp';
-import { setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
+import { resolveAllianceConfig, setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
 
 async function main(): Promise<void> {
   const apiKey = process.env['PINECONE_API_KEY']?.trim();
@@ -31,7 +30,7 @@ async function main(): Promise<void> {
     );
     return;
   }
-  const config = resolveConfig({ apiKey, indexName });
+  const config = resolveAllianceConfig({ apiKey, indexName });
 
   const ctx = createServer(config);
   ctx.setClient(

--- a/examples/alliance/guided-query-demo.ts
+++ b/examples/alliance/guided-query-demo.ts
@@ -18,9 +18,8 @@
 import {
   createServer,
   PineconeClient,
-  resolveConfig,
 } from '@will-cppa/pinecone-read-only-mcp';
-import { setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
+import { resolveAllianceConfig, setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
 
 async function main(): Promise<void> {
   const apiKey = process.env['PINECONE_API_KEY']?.trim();
@@ -33,7 +32,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const config = resolveConfig({ apiKey, indexName });
+  const config = resolveAllianceConfig({ apiKey, indexName });
   const ctx = createServer(config);
   ctx.setClient(
     new PineconeClient({

--- a/examples/alliance/suggest-flow-demo.ts
+++ b/examples/alliance/suggest-flow-demo.ts
@@ -19,9 +19,8 @@
 import {
   createServer,
   PineconeClient,
-  resolveConfig,
 } from '@will-cppa/pinecone-read-only-mcp';
-import { setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
+import { resolveAllianceConfig, setupAllianceServer } from '@will-cppa/pinecone-read-only-mcp/alliance';
 
 async function main(): Promise<void> {
   const apiKey = process.env['PINECONE_API_KEY']?.trim();
@@ -34,7 +33,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const config = resolveConfig({ apiKey, indexName });
+  const config = resolveAllianceConfig({ apiKey, indexName });
   const ctx = createServer(config);
   ctx.setClient(
     new PineconeClient({

--- a/src/__tests__/config-branding.compile-test.ts
+++ b/src/__tests__/config-branding.compile-test.ts
@@ -1,0 +1,23 @@
+/**
+ * Compile-time assertions for ServerConfig branding (Issue #3).
+ *
+ * Included in `tsc` / `npm run typecheck` (not `*.test.ts`). Misuse cases use
+ * `@ts-expect-error` so brand regressions fail CI when the guard stops working.
+ */
+
+import { resolveAllianceConfig } from '../alliance/config.js';
+import { resolveConfig } from '../core/config.js';
+import { setupCoreServer } from '../core/setup.js';
+import { setupAllianceServer } from '../alliance/setup.js';
+
+const coreCfg = resolveConfig({ apiKey: 'k', indexName: 'idx' });
+const allianceCfg = resolveAllianceConfig({ apiKey: 'k' });
+
+void setupCoreServer(coreCfg);
+void setupAllianceServer(allianceCfg);
+
+// @ts-expect-error Alliance config must not be passed to core setup
+void setupCoreServer(allianceCfg);
+
+// @ts-expect-error Core config must not be passed to Alliance setup
+void setupAllianceServer(coreCfg);

--- a/src/__tests__/config-branding.compile-test.ts
+++ b/src/__tests__/config-branding.compile-test.ts
@@ -1,5 +1,5 @@
 /**
- * Compile-time assertions for ServerConfig branding (Issue #3).
+ * Compile-time assertions for ServerConfig branding (Issue #172).
  *
  * Included in `tsc` / `npm run typecheck` (not `*.test.ts`). Misuse cases use
  * `@ts-expect-error` so brand regressions fail CI when the guard stops working.
@@ -7,6 +7,7 @@
 
 import { resolveAllianceConfig } from '../alliance/config.js';
 import { resolveConfig } from '../core/config.js';
+import { createServer } from '../core/server/server-context.js';
 import { setupCoreServer } from '../core/setup.js';
 import { setupAllianceServer } from '../alliance/setup.js';
 
@@ -21,3 +22,11 @@ void setupCoreServer(allianceCfg);
 
 // @ts-expect-error Core config must not be passed to Alliance setup
 void setupAllianceServer(coreCfg);
+
+const allianceCtx = createServer(allianceCfg);
+// @ts-expect-error Alliance context must not be passed to core setup
+void setupCoreServer({ context: allianceCtx });
+
+const coreCtx = createServer(coreCfg);
+// @ts-expect-error Core context must not be passed to Alliance setup
+void setupAllianceServer({ context: coreCtx });

--- a/src/alliance/config.ts
+++ b/src/alliance/config.ts
@@ -4,10 +4,11 @@
 
 import {
   asBool,
+  brandAllianceConfig,
   resolveConfig,
   trimOptional,
+  type AllianceServerConfig,
   type ConfigOverrides,
-  type ServerConfig,
 } from '../core/config.js';
 
 /** C++ Alliance default dense index when env/CLI omit `PINECONE_INDEX_NAME`. */
@@ -20,7 +21,7 @@ export const ALLIANCE_DEFAULT_RERANK_MODEL = 'bge-reranker-v2-m3';
 export const DEFAULT_ALLIANCE_RERANK_MODEL = ALLIANCE_DEFAULT_RERANK_MODEL;
 
 /**
- * Build {@link ServerConfig} for Alliance CLI and `setupAllianceServer`.
+ * Build {@link AllianceServerConfig} for Alliance CLI and `setupAllianceServer`.
  * Fills index and rerank from Alliance defaults when unset, then calls core `resolveConfig`.
  *
  * **Suggest-flow gate default:** After core resolution, `disableSuggestFlow` is overridden to
@@ -37,7 +38,7 @@ export const DEFAULT_ALLIANCE_RERANK_MODEL = ALLIANCE_DEFAULT_RERANK_MODEL;
 export function resolveAllianceConfig(
   overrides: ConfigOverrides = {},
   env: NodeJS.ProcessEnv = process.env
-): ServerConfig {
+): AllianceServerConfig {
   const indexName =
     trimOptional(overrides.indexName) ??
     trimOptional(env['PINECONE_INDEX_NAME']) ??
@@ -49,5 +50,7 @@ export function resolveAllianceConfig(
   const cfg = resolveConfig({ ...overrides, indexName, rerankModel }, env);
   const disableSuggestFlow =
     overrides.disableSuggestFlow ?? asBool(env['PINECONE_DISABLE_SUGGEST_FLOW'], false);
-  return { ...cfg, disableSuggestFlow };
+  return brandAllianceConfig({ ...cfg, disableSuggestFlow });
 }
+
+export type { AllianceServerConfig } from '../core/config.js';

--- a/src/alliance/index.ts
+++ b/src/alliance/index.ts
@@ -10,6 +10,7 @@ export {
   DEFAULT_ALLIANCE_RERANK_MODEL,
   resolveAllianceConfig,
 } from './config.js';
+export type { AllianceServerConfig } from './config.js';
 export { setupAllianceServer, type SetupAllianceServerOptions } from './setup.js';
 export {
   registerBuiltinUrlGenerators,

--- a/src/alliance/index.ts
+++ b/src/alliance/index.ts
@@ -11,6 +11,7 @@ export {
   resolveAllianceConfig,
 } from './config.js';
 export type { AllianceServerConfig } from './config.js';
+export type { AllianceServerContext } from '../core/server/server-context.js';
 export { setupAllianceServer, type SetupAllianceServerOptions } from './setup.js';
 export {
   registerBuiltinUrlGenerators,

--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -99,6 +99,11 @@ export async function setupAllianceServer(
       resolvedCtx.setConfig(opts.config);
     } else if (!resolvedCtx.hasConfig()) {
       resolvedCtx.setConfig(resolveAllianceConfig({}));
+    } else {
+      const stored = resolvedCtx.getConfigIfSet();
+      if (stored) {
+        assertAllianceServerConfig(stored);
+      }
     }
     server = await setupCoreServerOnContext(resolvedCtx, instructions);
   } else {

--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -1,6 +1,6 @@
 import { ALLIANCE_SERVER_INSTRUCTIONS } from '../constants.js';
 import type { AllianceServerConfig, ServerConfigBase } from '../core/config.js';
-import { createServer, type ServerContext } from '../core/server/server-context.js';
+import { createServer, type AllianceServerContext } from '../core/server/server-context.js';
 import { resolveAllianceConfig } from './config.js';
 import { setupCoreServerOnContext, type ServerHandle } from '../core/setup.js';
 import { registerBuiltinUrlGenerators } from './url-builtins.js';
@@ -11,7 +11,7 @@ import { registerSuggestQueryParamsTool } from './tools/suggest-query-params-too
  */
 export type SetupAllianceServerOptions = {
   config?: AllianceServerConfig;
-  context?: ServerContext;
+  context?: AllianceServerContext;
   /** MCP server instructions; defaults to {@link ALLIANCE_SERVER_INSTRUCTIONS}. */
   instructions?: string;
 };
@@ -69,7 +69,7 @@ export async function setupAllianceServer(
   const instructions = opts.instructions ?? ALLIANCE_SERVER_INSTRUCTIONS;
 
   let server: ServerHandle;
-  let resolvedCtx: ServerContext;
+  let resolvedCtx: AllianceServerContext;
 
   if (opts.context) {
     resolvedCtx = opts.context;

--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -2,7 +2,7 @@ import { ALLIANCE_SERVER_INSTRUCTIONS } from '../constants.js';
 import type { AllianceServerConfig, ServerConfigBase } from '../core/config.js';
 import { createServer, type ServerContext } from '../core/server/server-context.js';
 import { resolveAllianceConfig } from './config.js';
-import { setupCoreServer, type ServerHandle } from '../core/setup.js';
+import { setupCoreServerOnContext, type ServerHandle } from '../core/setup.js';
 import { registerBuiltinUrlGenerators } from './url-builtins.js';
 import { registerSuggestQueryParamsTool } from './tools/suggest-query-params-tool.js';
 
@@ -74,13 +74,21 @@ export async function setupAllianceServer(
   if (opts.context) {
     resolvedCtx = opts.context;
     if (opts.config !== undefined) {
+      if (resolvedCtx.hasInjectedClient()) {
+        throw new Error(
+          'Passing both config and context clears an injected Pinecone client. ' +
+            'Omit config when reusing a pre-configured context, or call setClient() after setup.'
+        );
+      }
       resolvedCtx.setConfig(opts.config);
+    } else if (!resolvedCtx.hasConfig()) {
+      resolvedCtx.setConfig(resolveAllianceConfig({}));
     }
-    server = await setupCoreServer({ context: resolvedCtx, instructions });
+    server = await setupCoreServerOnContext(resolvedCtx, instructions);
   } else {
     const config = opts.config ?? resolveAllianceConfig({});
     const ctx = createServer(config);
-    server = await setupCoreServer({ context: ctx, instructions });
+    server = await setupCoreServerOnContext(ctx, instructions);
     resolvedCtx = ctx;
   }
 

--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -1,8 +1,8 @@
 import { ALLIANCE_SERVER_INSTRUCTIONS } from '../constants.js';
-import type { ServerConfig } from '../core/config.js';
-import { resolveDefaultServerContext, type ServerContext } from '../core/server/server-context.js';
+import type { AllianceServerConfig, ServerConfigBase } from '../core/config.js';
+import { createServer, type ServerContext } from '../core/server/server-context.js';
 import { resolveAllianceConfig } from './config.js';
-import { setupCoreServer, type ServerHandle, type SetupCoreServerOptions } from '../core/setup.js';
+import { setupCoreServer, type ServerHandle } from '../core/setup.js';
 import { registerBuiltinUrlGenerators } from './url-builtins.js';
 import { registerSuggestQueryParamsTool } from './tools/suggest-query-params-tool.js';
 
@@ -10,18 +10,18 @@ import { registerSuggestQueryParamsTool } from './tools/suggest-query-params-too
  * Options for {@link setupAllianceServer}.
  */
 export type SetupAllianceServerOptions = {
-  config?: ServerConfig;
+  config?: AllianceServerConfig;
   context?: ServerContext;
   /** MCP server instructions; defaults to {@link ALLIANCE_SERVER_INSTRUCTIONS}. */
   instructions?: string;
 };
 
-function isServerConfig(value: unknown): value is ServerConfig {
+function isServerConfig(value: unknown): value is AllianceServerConfig {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as ServerConfig).apiKey === 'string' &&
-    typeof (value as ServerConfig).indexName === 'string'
+    typeof (value as ServerConfigBase).apiKey === 'string' &&
+    typeof (value as ServerConfigBase).indexName === 'string'
   );
 }
 
@@ -38,7 +38,7 @@ function isSetupAllianceServerOptions(value: unknown): value is SetupAllianceSer
 }
 
 function normalizeSetupAllianceArgs(
-  configOrOptions?: ServerConfig | SetupAllianceServerOptions,
+  configOrOptions?: AllianceServerConfig | SetupAllianceServerOptions,
   legacyOptions?: Pick<SetupAllianceServerOptions, 'instructions'>
 ): SetupAllianceServerOptions {
   if (configOrOptions === undefined) {
@@ -50,7 +50,9 @@ function normalizeSetupAllianceArgs(
   if (isSetupAllianceServerOptions(configOrOptions)) {
     return { ...configOrOptions, ...legacyOptions };
   }
-  throw new TypeError('configOrOptions must be a ServerConfig or SetupAllianceServerOptions');
+  throw new TypeError(
+    'configOrOptions must be an AllianceServerConfig or SetupAllianceServerOptions'
+  );
 }
 
 /**
@@ -60,7 +62,7 @@ function normalizeSetupAllianceArgs(
  * When `config` is omitted, resolves env via {@link resolveAllianceConfig} (Alliance index/rerank defaults when unset).
  */
 export async function setupAllianceServer(
-  configOrOptions?: ServerConfig | SetupAllianceServerOptions,
+  configOrOptions?: AllianceServerConfig | SetupAllianceServerOptions,
   legacyOptions?: Pick<SetupAllianceServerOptions, 'instructions'>
 ): Promise<ServerHandle> {
   const opts = normalizeSetupAllianceArgs(configOrOptions, legacyOptions);
@@ -71,18 +73,15 @@ export async function setupAllianceServer(
 
   if (opts.context) {
     resolvedCtx = opts.context;
-    const coreOpts: SetupCoreServerOptions = { context: resolvedCtx, instructions };
     if (opts.config !== undefined) {
-      coreOpts.config = opts.config;
+      resolvedCtx.setConfig(opts.config);
     }
-    server = await setupCoreServer(coreOpts);
+    server = await setupCoreServer({ context: resolvedCtx, instructions });
   } else {
     const config = opts.config ?? resolveAllianceConfig({});
-    server = await setupCoreServer({
-      config: opts.config ?? config,
-      instructions,
-    });
-    resolvedCtx = resolveDefaultServerContext();
+    const ctx = createServer(config);
+    server = await setupCoreServer({ context: ctx, instructions });
+    resolvedCtx = ctx;
   }
 
   registerBuiltinUrlGenerators(resolvedCtx);

--- a/src/alliance/setup.ts
+++ b/src/alliance/setup.ts
@@ -1,5 +1,6 @@
 import { ALLIANCE_SERVER_INSTRUCTIONS } from '../constants.js';
 import type { AllianceServerConfig, ServerConfigBase } from '../core/config.js';
+import { getServerConfigLineage } from '../core/config.js';
 import { createServer, type AllianceServerContext } from '../core/server/server-context.js';
 import { resolveAllianceConfig } from './config.js';
 import { setupCoreServerOnContext, type ServerHandle } from '../core/setup.js';
@@ -17,12 +18,23 @@ export type SetupAllianceServerOptions = {
 };
 
 function isServerConfig(value: unknown): value is AllianceServerConfig {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as ServerConfigBase).apiKey === 'string' &&
-    typeof (value as ServerConfigBase).indexName === 'string'
-  );
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const base = value as ServerConfigBase;
+  if (typeof base.apiKey !== 'string' || typeof base.indexName !== 'string') {
+    return false;
+  }
+  return getServerConfigLineage(base) === 'alliance';
+}
+
+function assertAllianceServerConfig(config: ServerConfigBase): AllianceServerConfig {
+  if (getServerConfigLineage(config) !== 'alliance') {
+    throw new TypeError(
+      'Expected AllianceServerConfig. Use setupCoreServer for core-branded config.'
+    );
+  }
+  return config as AllianceServerConfig;
 }
 
 function isSetupAllianceServerOptions(value: unknown): value is SetupAllianceServerOptions {
@@ -67,6 +79,10 @@ export async function setupAllianceServer(
 ): Promise<ServerHandle> {
   const opts = normalizeSetupAllianceArgs(configOrOptions, legacyOptions);
   const instructions = opts.instructions ?? ALLIANCE_SERVER_INSTRUCTIONS;
+
+  if (opts.config) {
+    assertAllianceServerConfig(opts.config);
+  }
 
   let server: ServerHandle;
   let resolvedCtx: AllianceServerContext;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,8 +1,9 @@
 /**
  * Shared runtime config types and resolver.
  *
- * `ServerConfig` is the single source of truth flowed from `parseCli()` →
- * `setupCoreServer(config)` / `setupAllianceServer(config)` → every collaborator.
+ * Branded types ({@link CoreServerConfig}, {@link AllianceServerConfig}) distinguish
+ * configs produced by {@link resolveConfig} vs {@link resolveAllianceConfig} at compile time.
+ * {@link ServerConfigBase} is the shared structural type for read paths (e.g. `ctx.getConfig()`).
  * Modules MUST NOT read `process.env` directly anymore — they receive their slice of the config.
  */
 
@@ -14,13 +15,16 @@ export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 /** Allowed log output formats. */
 export type LogFormat = 'text' | 'json';
 
+declare const coreServerConfigBrand: unique symbol;
+declare const allianceServerConfigBrand: unique symbol;
+
 /**
- * Unified runtime configuration for the MCP server.
+ * Unified runtime configuration for the MCP server (structural fields only).
  *
  * Built once by `parseCli()` (or constructed directly by library consumers)
  * and threaded through setup. `apiKey` and `indexName` are required.
  */
-export interface ServerConfig {
+export interface ServerConfigBase {
   /** Pinecone API key. Required. */
   apiKey: string;
   /** Dense (hybrid) index name (`PINECONE_INDEX_NAME` or CLI `--index-name`). Required. */
@@ -51,6 +55,30 @@ export interface ServerConfig {
   disableSuggestFlow: boolean;
   /** When true, on-startup probe verifies dense + sparse indexes exist. */
   checkIndexes: boolean;
+}
+
+/** Backward-compatible alias for {@link ServerConfigBase} (read paths, docs). */
+export type ServerConfig = ServerConfigBase;
+
+/** Config produced by {@link resolveConfig} (core defaults: gate off, explicit index required). */
+export type CoreServerConfig = ServerConfigBase & { readonly [coreServerConfigBrand]: 'core' };
+
+/** Config produced by {@link resolveAllianceConfig} (Alliance defaults: gate on, `rag-hybrid` index). */
+export type AllianceServerConfig = ServerConfigBase & {
+  readonly [allianceServerConfigBrand]: 'alliance';
+};
+
+/** Branded union accepted by {@link createServer} and {@link createIsolatedContext}. */
+export type AnyServerConfig = CoreServerConfig | AllianceServerConfig;
+
+/** Attach the core brand after {@link resolveConfig} resolution (zero runtime cost). */
+export function brandCoreConfig(config: ServerConfigBase): CoreServerConfig {
+  return config as CoreServerConfig;
+}
+
+/** Attach the Alliance brand after {@link resolveAllianceConfig} resolution (zero runtime cost). */
+export function brandAllianceConfig(config: ServerConfigBase): AllianceServerConfig {
+  return config as AllianceServerConfig;
 }
 
 /** Default per-call timeout for Pinecone requests, in milliseconds. */
@@ -103,7 +131,7 @@ export interface ConfigOverrides {
 }
 
 /**
- * Build a `ServerConfig` from CLI overrides, environment variables, and defaults.
+ * Build a {@link CoreServerConfig} from CLI overrides, environment variables, and defaults.
  * CLI > env > default precedence is preserved.
  *
  * Output is the `config` half of the embedder pattern `{ config, composition }`.
@@ -124,7 +152,7 @@ export interface ConfigOverrides {
 export function resolveConfig(
   overrides: ConfigOverrides,
   env: NodeJS.ProcessEnv = process.env
-): ServerConfig {
+): CoreServerConfig {
   const apiKey = (overrides.apiKey ?? env['PINECONE_API_KEY'] ?? '').trim();
   if (!apiKey) {
     throw new Error(
@@ -164,7 +192,7 @@ export function resolveConfig(
     overrides.disableSuggestFlow ?? asBool(env['PINECONE_DISABLE_SUGGEST_FLOW'], true);
   const checkIndexes = overrides.checkIndexes ?? asBool(env['PINECONE_CHECK_INDEXES'], false);
 
-  return {
+  return brandCoreConfig({
     apiKey,
     indexName,
     sparseIndexName,
@@ -176,5 +204,5 @@ export function resolveConfig(
     requestTimeoutMs,
     disableSuggestFlow,
     checkIndexes,
-  };
+  });
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -71,13 +71,29 @@ export type AllianceServerConfig = ServerConfigBase & {
 /** Branded union accepted by {@link createServer} and {@link createIsolatedContext}. */
 export type AnyServerConfig = CoreServerConfig | AllianceServerConfig;
 
-/** Attach the core brand after {@link resolveConfig} resolution (zero runtime cost). */
+/** Runtime lineage marker (compile-time brands are erased). */
+export const SERVER_CONFIG_LINEAGE = Symbol.for('@will-cppa/pinecone-read-only-mcp.config-lineage');
+
+export type ServerConfigLineage = 'core' | 'alliance';
+
+type ServerConfigLineageHost = ServerConfigBase & {
+  [SERVER_CONFIG_LINEAGE]?: ServerConfigLineage;
+};
+
+/** Read config lineage set by {@link brandCoreConfig} / {@link brandAllianceConfig}. */
+export function getServerConfigLineage(config: ServerConfigBase): ServerConfigLineage | undefined {
+  return (config as ServerConfigLineageHost)[SERVER_CONFIG_LINEAGE];
+}
+
+/** Attach the core brand after {@link resolveConfig} resolution. */
 export function brandCoreConfig(config: ServerConfigBase): CoreServerConfig {
+  (config as ServerConfigLineageHost)[SERVER_CONFIG_LINEAGE] = 'core';
   return config as CoreServerConfig;
 }
 
-/** Attach the Alliance brand after {@link resolveAllianceConfig} resolution (zero runtime cost). */
+/** Attach the Alliance brand after {@link resolveAllianceConfig} resolution. */
 export function brandAllianceConfig(config: ServerConfigBase): AllianceServerConfig {
+  (config as ServerConfigLineageHost)[SERVER_CONFIG_LINEAGE] = 'alliance';
   return config as AllianceServerConfig;
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -17,6 +17,7 @@ export type {
   ServerContextComposition,
   NamespaceCacheSeed,
   SuggestionFlowSeedEntry,
+  CoreServerContext,
 } from './server/server-context.js';
 export {
   validateMetadataFilter,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,6 +18,7 @@ export type {
   NamespaceCacheSeed,
   SuggestionFlowSeedEntry,
   CoreServerContext,
+  AllianceServerContext,
 } from './server/server-context.js';
 export {
   validateMetadataFilter,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,6 +11,7 @@ export {
   ServerContext,
   createServer,
   createIsolatedContext,
+  createUnconfiguredAllianceContext,
   getDefaultServerContext,
 } from './server/server-context.js';
 export type {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -63,7 +63,15 @@ export {
 } from './server/url-registry.js';
 export type { UrlGenerationResult, UrlGenerator, UrlGeneratorFn } from './server/url-registry.js';
 export { resolveConfig, trimOptional } from './config.js';
-export type { ServerConfig, LogLevel, LogFormat, ConfigOverrides } from './config.js';
+export type {
+  ServerConfig,
+  ServerConfigBase,
+  CoreServerConfig,
+  AnyServerConfig,
+  LogLevel,
+  LogFormat,
+  ConfigOverrides,
+} from './config.js';
 export { PineconeClient } from './pinecone-client.js';
 export type {
   PineconeClientConfig,

--- a/src/core/server/config-context.ts
+++ b/src/core/server/config-context.ts
@@ -1,4 +1,4 @@
-import type { ServerConfig } from '../config.js';
+import type { ServerConfigBase } from '../config.js';
 import { warnLegacyFacade } from './legacy-facade-warn.js';
 import {
   resolveDefaultServerContext,
@@ -14,7 +14,7 @@ import {
  * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.setConfig
  */
-export function setServerConfig(config: ServerConfig): void {
+export function setServerConfig(config: ServerConfigBase): void {
   warnLegacyFacade('setServerConfig');
   setPendingServerConfig(config);
 }
@@ -45,7 +45,7 @@ export function resetServerConfig(): void {
  * instead. See docs/MIGRATION.md#030-legacy-module-facade-deprecations.
  * @see ServerContext.getConfig
  */
-export function getServerConfig(): ServerConfig {
+export function getServerConfig(): ServerConfigBase {
   warnLegacyFacade('getServerConfig');
   return resolveDefaultServerContext().getConfig();
 }

--- a/src/core/server/server-context.legacy-facade.test.ts
+++ b/src/core/server/server-context.legacy-facade.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveAllianceConfig } from '../../alliance/config.js';
 import { setupAllianceServer } from '../../alliance/setup.js';
 import { setPineconeClient, setupCoreServer, teardownServer } from '../index.js';
 import { getPineconeClient } from './client-context.js';
@@ -46,10 +47,10 @@ describe('legacy facade vs explicit setup context', () => {
   it('setupAllianceServer with explicit context throws on legacy facade use', async () => {
     isolateFromDefaultContext();
     setPineconeClient({ query: vi.fn() } as never);
-    const isolatedCtx = createTestServerContext({
-      config: resolveTestConfig({ disableSuggestFlow: false }),
-      client: { query: vi.fn() } as never,
-    });
+    const isolatedCtx = createIsolatedContext(
+      resolveAllianceConfig({ apiKey: 'isolated', indexName: 'idx-iso' }),
+      { client: { query: vi.fn() } as never }
+    );
 
     await setupAllianceServer({ context: isolatedCtx });
 

--- a/src/core/server/server-context.ts
+++ b/src/core/server/server-context.ts
@@ -391,6 +391,9 @@ export class ServerContext<
 /** Context bound to a core-resolved config; accepted by {@link setupCoreServer}. */
 export type CoreServerContext = ServerContext<CoreServerConfig>;
 
+/** Context bound to an Alliance-resolved config; accepted by {@link setupAllianceServer}. */
+export type AllianceServerContext = ServerContext<AllianceServerConfig>;
+
 let defaultContext: ServerContext | null = null;
 let facadeSupersededBy: ServerContext | null = null;
 let pendingConfig: ServerConfigBase | null = null;

--- a/src/core/server/server-context.ts
+++ b/src/core/server/server-context.ts
@@ -1,4 +1,4 @@
-import type { ServerConfig } from '../config.js';
+import type { AnyServerConfig, ServerConfigBase } from '../config.js';
 import { resolveConfig } from '../config.js';
 import { PineconeClient } from '../pinecone-client.js';
 import { warnLegacyFacade } from './legacy-facade-warn.js';
@@ -51,7 +51,7 @@ function asString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
 }
 
-function buildPineconeClient(config: ServerConfig): PineconeClient {
+function buildPineconeClient(config: ServerConfigBase): PineconeClient {
   return new PineconeClient({
     apiKey: config.apiKey,
     indexName: config.indexName,
@@ -71,12 +71,12 @@ export class ServerContext implements AsyncDisposable {
   private toolsRegistered = false;
   private client: PineconeClient | null = null;
   private clientExplicitlySet = false;
-  private configValue: ServerConfig | null = null;
+  private configValue: ServerConfigBase | null = null;
   private readonly urlGenerators = new Map<string, UrlGeneratorFn>();
   private readonly suggestionFlow = new Map<string, FlowState>();
   private namespacesCache: CacheEntry | null = null;
 
-  constructor(config?: ServerConfig, composition?: ServerContextComposition) {
+  constructor(config?: ServerConfigBase, composition?: ServerContextComposition) {
     if (config) {
       this.configValue = config;
     }
@@ -118,18 +118,18 @@ export class ServerContext implements AsyncDisposable {
   }
 
   /** Build a context with an externally-constructed Pinecone client. */
-  static fromClient(config: ServerConfig, client: PineconeClient): ServerContext {
+  static fromClient(config: ServerConfigBase, client: PineconeClient): ServerContext {
     return new ServerContext(config, { client });
   }
 
-  getConfig(): ServerConfig {
+  getConfig(): ServerConfigBase {
     if (!this.configValue) {
       this.configValue = resolveConfig({});
     }
     return this.configValue;
   }
 
-  setConfig(config: ServerConfig): void {
+  setConfig(config: ServerConfigBase): void {
     this.configValue = config;
     this.invalidateConfigDerivedState();
   }
@@ -370,7 +370,7 @@ export class ServerContext implements AsyncDisposable {
 
 let defaultContext: ServerContext | null = null;
 let facadeSupersededBy: ServerContext | null = null;
-let pendingConfig: ServerConfig | null = null;
+let pendingConfig: ServerConfigBase | null = null;
 let pendingComposition: ServerContextComposition | null = null;
 
 const LEGACY_FACADE_SUPERSEDED_MESSAGE =
@@ -436,7 +436,7 @@ export function setDefaultServerContext(ctx: ServerContext | null): void {
 }
 
 /** Stash config until the default context is first materialized. */
-export function setPendingServerConfig(config: ServerConfig): void {
+export function setPendingServerConfig(config: ServerConfigBase): void {
   pendingConfig = config;
   if (defaultContext) {
     defaultContext.setConfig(config);
@@ -456,7 +456,7 @@ export function teardownDefaultServerContext(): void {
 
 /** Multi-tenant: no process-global side effects. */
 export function createIsolatedContext(
-  config: ServerConfig,
+  config: AnyServerConfig,
   composition?: ServerContextComposition
 ): ServerContext {
   return new ServerContext(config, composition);
@@ -464,7 +464,7 @@ export function createIsolatedContext(
 
 /** Create a configured context and install it as the process default. */
 export function createServer(
-  config: ServerConfig,
+  config: AnyServerConfig,
   composition?: ServerContextComposition
 ): ServerContext {
   const ctx = new ServerContext(config, composition);

--- a/src/core/server/server-context.ts
+++ b/src/core/server/server-context.ts
@@ -31,6 +31,15 @@ export type SuggestionFlowSeedEntry = {
   user_query: string;
 };
 
+/** Constructor options for contexts that must not lazy-resolve core defaults. */
+export type ServerContextInitOptions = {
+  /**
+   * When true, {@link getConfig} throws until Alliance config is seeded
+   * (see {@link createUnconfiguredAllianceContext}).
+   */
+  unconfiguredAlliance?: boolean;
+};
+
 /** Pre-built dependencies accepted by {@link ServerContext} and factory helpers. */
 export interface ServerContextComposition {
   client?: PineconeClient;
@@ -79,11 +88,13 @@ export class ServerContext<
   private client: PineconeClient | null = null;
   private clientExplicitlySet = false;
   private configValue: T | null = null;
+  private readonly unconfiguredAlliance: boolean;
   private readonly urlGenerators = new Map<string, UrlGeneratorFn>();
   private readonly suggestionFlow = new Map<string, FlowState>();
   private namespacesCache: CacheEntry | null = null;
 
-  constructor(config?: T, composition?: ServerContextComposition) {
+  constructor(config?: T, composition?: ServerContextComposition, init?: ServerContextInitOptions) {
+    this.unconfiguredAlliance = init?.unconfiguredAlliance ?? false;
     if (config) {
       this.configValue = config;
     }
@@ -144,6 +155,11 @@ export class ServerContext<
 
   getConfig(): T {
     if (!this.configValue) {
+      if (this.unconfiguredAlliance) {
+        throw new Error(
+          'Alliance ServerContext has no config. Call setConfig(), createServer(resolveAllianceConfig(...)), or setupAllianceServer before getConfig().'
+        );
+      }
       this.configValue = resolveConfig({}) as unknown as T;
     }
     return this.configValue;
@@ -393,6 +409,16 @@ export type CoreServerContext = ServerContext<CoreServerConfig>;
 
 /** Context bound to an Alliance-resolved config; accepted by {@link setupAllianceServer}. */
 export type AllianceServerContext = ServerContext<AllianceServerConfig>;
+
+/**
+ * Empty Alliance context that rejects core lazy-resolve in {@link ServerContext.getConfig}
+ * until {@link setupAllianceServer} or {@link ServerContext.setConfig} seeds Alliance config.
+ */
+export function createUnconfiguredAllianceContext(): AllianceServerContext {
+  return new ServerContext<AllianceServerConfig>(undefined, undefined, {
+    unconfiguredAlliance: true,
+  });
+}
 
 let defaultContext: ServerContext | null = null;
 let facadeSupersededBy: ServerContext | null = null;

--- a/src/core/server/server-context.ts
+++ b/src/core/server/server-context.ts
@@ -1,4 +1,9 @@
-import type { AnyServerConfig, ServerConfigBase } from '../config.js';
+import type {
+  AnyServerConfig,
+  AllianceServerConfig,
+  CoreServerConfig,
+  ServerConfigBase,
+} from '../config.js';
 import { resolveConfig } from '../config.js';
 import { PineconeClient } from '../pinecone-client.js';
 import { warnLegacyFacade } from './legacy-facade-warn.js';
@@ -66,17 +71,19 @@ function buildPineconeClient(config: ServerConfigBase): PineconeClient {
  * Encapsulates per-server state: Pinecone client, config, URL registry,
  * suggest-flow gate, and namespaces cache.
  */
-export class ServerContext implements AsyncDisposable {
+export class ServerContext<
+  T extends ServerConfigBase = ServerConfigBase,
+> implements AsyncDisposable {
   disposed = false;
   private toolsRegistered = false;
   private client: PineconeClient | null = null;
   private clientExplicitlySet = false;
-  private configValue: ServerConfigBase | null = null;
+  private configValue: T | null = null;
   private readonly urlGenerators = new Map<string, UrlGeneratorFn>();
   private readonly suggestionFlow = new Map<string, FlowState>();
   private namespacesCache: CacheEntry | null = null;
 
-  constructor(config?: ServerConfigBase, composition?: ServerContextComposition) {
+  constructor(config?: T, composition?: ServerContextComposition) {
     if (config) {
       this.configValue = config;
     }
@@ -118,18 +125,31 @@ export class ServerContext implements AsyncDisposable {
   }
 
   /** Build a context with an externally-constructed Pinecone client. */
-  static fromClient(config: ServerConfigBase, client: PineconeClient): ServerContext {
+  static fromClient<T extends ServerConfigBase>(
+    config: T,
+    client: PineconeClient
+  ): ServerContext<T> {
     return new ServerContext(config, { client });
   }
 
-  getConfig(): ServerConfigBase {
+  /** Whether config was set at construction or via {@link setConfig} (does not lazy-resolve). */
+  hasConfig(): boolean {
+    return this.configValue !== null;
+  }
+
+  /** Return stored config without lazy env resolution; `null` when unset. */
+  getConfigIfSet(): T | null {
+    return this.configValue;
+  }
+
+  getConfig(): T {
     if (!this.configValue) {
-      this.configValue = resolveConfig({});
+      this.configValue = resolveConfig({}) as unknown as T;
     }
     return this.configValue;
   }
 
-  setConfig(config: ServerConfigBase): void {
+  setConfig(config: T): void {
     this.configValue = config;
     this.invalidateConfigDerivedState();
   }
@@ -368,6 +388,9 @@ export class ServerContext implements AsyncDisposable {
   }
 }
 
+/** Context bound to a core-resolved config; accepted by {@link setupCoreServer}. */
+export type CoreServerContext = ServerContext<CoreServerConfig>;
+
 let defaultContext: ServerContext | null = null;
 let facadeSupersededBy: ServerContext | null = null;
 let pendingConfig: ServerConfigBase | null = null;
@@ -456,6 +479,14 @@ export function teardownDefaultServerContext(): void {
 
 /** Multi-tenant: no process-global side effects. */
 export function createIsolatedContext(
+  config: CoreServerConfig,
+  composition?: ServerContextComposition
+): CoreServerContext;
+export function createIsolatedContext(
+  config: AllianceServerConfig,
+  composition?: ServerContextComposition
+): ServerContext<AllianceServerConfig>;
+export function createIsolatedContext(
   config: AnyServerConfig,
   composition?: ServerContextComposition
 ): ServerContext {
@@ -463,6 +494,14 @@ export function createIsolatedContext(
 }
 
 /** Create a configured context and install it as the process default. */
+export function createServer(
+  config: CoreServerConfig,
+  composition?: ServerContextComposition
+): CoreServerContext;
+export function createServer(
+  config: AllianceServerConfig,
+  composition?: ServerContextComposition
+): ServerContext<AllianceServerConfig>;
 export function createServer(
   config: AnyServerConfig,
   composition?: ServerContextComposition

--- a/src/core/server/tools/test-helpers.ts
+++ b/src/core/server/tools/test-helpers.ts
@@ -6,6 +6,7 @@ import type { ConfigOverrides, CoreServerConfig } from '../../config.js';
 import {
   ServerContext,
   teardownDefaultServerContext,
+  type CoreServerContext,
   type ServerContextComposition,
 } from '../server-context.js';
 import type { ToolError, ToolErrorCode } from '../tool-error.js';
@@ -142,7 +143,7 @@ export function createTestServerContext(options?: {
   config?: ConfigOverrides;
   client?: PineconeClient;
   composition?: ServerContextComposition;
-}): ServerContext {
+}): CoreServerContext {
   const config = resolveTestConfig(options?.config);
   const composition: ServerContextComposition = {
     ...options?.composition,

--- a/src/core/server/tools/test-helpers.ts
+++ b/src/core/server/tools/test-helpers.ts
@@ -2,7 +2,7 @@ import type { z } from 'zod';
 import type { HybridQueryResult, SearchResult } from '../../../types.js';
 import { resolveConfig } from '../../config.js';
 import type { PineconeClient } from '../../pinecone-client.js';
-import type { ConfigOverrides, ServerConfig } from '../../config.js';
+import type { ConfigOverrides, CoreServerConfig } from '../../config.js';
 import {
   ServerContext,
   teardownDefaultServerContext,
@@ -122,7 +122,7 @@ export function makeNamespaceCacheEntry(
 /** Stable TTL (seconds) for tests — overrides env `PINECONE_CACHE_TTL_SECONDS`. */
 const TEST_CACHE_TTL_SECONDS = 3600;
 
-export function resolveTestConfig(overrides: ConfigOverrides = {}): ServerConfig {
+export function resolveTestConfig(overrides: ConfigOverrides = {}): CoreServerConfig {
   return resolveConfig({
     apiKey: 'sk-test',
     indexName: 'test-index',

--- a/src/core/setup-guards.test.ts
+++ b/src/core/setup-guards.test.ts
@@ -84,13 +84,13 @@ describe('setup guards (CodeRabbit PR #150)', () => {
 
   it('throws TypeError for invalid setupCoreServer options object', async () => {
     await expect(setupCoreServer({ foo: 'bar' } as never)).rejects.toThrow(
-      /ServerConfig or SetupCoreServerOptions/
+      /CoreServerConfig or SetupCoreServerOptions/
     );
   });
 
   it('throws TypeError for invalid setupAllianceServer options object', async () => {
     await expect(setupAllianceServer({ foo: 'bar' } as never)).rejects.toThrow(
-      /ServerConfig or SetupAllianceServerOptions/
+      /AllianceServerConfig or SetupAllianceServerOptions/
     );
   });
 });

--- a/src/core/setup-guards.test.ts
+++ b/src/core/setup-guards.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveAllianceConfig } from '../alliance/config.js';
 import { setupAllianceServer } from '../alliance/setup.js';
-import type { AllianceServerConfig } from './config.js';
 import { setPineconeClient, setupCoreServer, teardownServer } from './index.js';
 import {
   ServerContext,
+  createUnconfiguredAllianceContext,
   createIsolatedContext,
   getDefaultServerContext,
   setDefaultServerContext,
@@ -36,8 +36,9 @@ describe('setup guards (CodeRabbit PR #150)', () => {
 
   it('installs Alliance defaults on context without config (no core lazy-resolve)', async () => {
     isolateFromDefaultContext();
-    const ctx = new ServerContext<AllianceServerConfig>();
+    const ctx = createUnconfiguredAllianceContext();
     expect(ctx.hasConfig()).toBe(false);
+    expect(() => ctx.getConfig()).toThrow(/Alliance ServerContext has no config/);
 
     vi.stubEnv('PINECONE_API_KEY', 'sk-alliance-default');
     try {
@@ -113,6 +114,22 @@ describe('setup guards (CodeRabbit PR #150)', () => {
   it('throws TypeError for invalid setupAllianceServer options object', async () => {
     await expect(setupAllianceServer({ foo: 'bar' } as never)).rejects.toThrow(
       /AllianceServerConfig or SetupAllianceServerOptions/
+    );
+  });
+
+  it('rejects Alliance-branded config at runtime on setupCoreServer', async () => {
+    const allianceCfg = resolveAllianceConfig({ apiKey: 'sk-test', indexName: 'idx' });
+    await expect(setupCoreServer(allianceCfg as never)).rejects.toThrow(/CoreServerConfig/);
+    await expect(setupCoreServer({ config: allianceCfg } as never)).rejects.toThrow(
+      /CoreServerConfig/
+    );
+  });
+
+  it('rejects core-branded config at runtime on setupAllianceServer', async () => {
+    const coreCfg = resolveTestConfig({ apiKey: 'sk-test', indexName: 'idx' });
+    await expect(setupAllianceServer(coreCfg as never)).rejects.toThrow(/AllianceServerConfig/);
+    await expect(setupAllianceServer({ config: coreCfg } as never)).rejects.toThrow(
+      /AllianceServerConfig/
     );
   });
 });

--- a/src/core/setup-guards.test.ts
+++ b/src/core/setup-guards.test.ts
@@ -132,4 +132,20 @@ describe('setup guards (CodeRabbit PR #150)', () => {
       /AllianceServerConfig/
     );
   });
+
+  it('rejects context with cross-branded config at runtime on setupCoreServer', async () => {
+    isolateFromDefaultContext();
+    const allianceCfg = resolveAllianceConfig({ apiKey: 'sk-test', indexName: 'idx' });
+    const ctx = createIsolatedContext(allianceCfg);
+    await expect(setupCoreServer({ context: ctx as never })).rejects.toThrow(/CoreServerConfig/);
+  });
+
+  it('rejects context with cross-branded config at runtime on setupAllianceServer', async () => {
+    isolateFromDefaultContext();
+    const coreCfg = resolveTestConfig({ apiKey: 'sk-test', indexName: 'idx' });
+    const ctx = createIsolatedContext(coreCfg);
+    await expect(setupAllianceServer({ context: ctx as never })).rejects.toThrow(
+      /AllianceServerConfig/
+    );
+  });
 });

--- a/src/core/setup-guards.test.ts
+++ b/src/core/setup-guards.test.ts
@@ -28,6 +28,22 @@ describe('setup guards (CodeRabbit PR #150)', () => {
     expect(ctx.getClient()).toBe(mockClient);
   });
 
+  it('installs Alliance defaults on context without config (no core lazy-resolve)', async () => {
+    isolateFromDefaultContext();
+    const ctx = new ServerContext();
+    expect(ctx.hasConfig()).toBe(false);
+
+    vi.stubEnv('PINECONE_API_KEY', 'sk-alliance-default');
+    try {
+      await setupAllianceServer({ context: ctx });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(ctx.hasConfig()).toBe(true);
+    expect(ctx.getConfig().disableSuggestFlow).toBe(false);
+  });
+
   it('allows config update when context only has a lazy-built client', async () => {
     isolateFromDefaultContext();
     const cfgA = resolveTestConfig({ apiKey: 'lazy-config-a', indexName: 'idx-a' });

--- a/src/core/setup-guards.test.ts
+++ b/src/core/setup-guards.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveAllianceConfig } from '../alliance/config.js';
 import { setupAllianceServer } from '../alliance/setup.js';
+import type { AllianceServerConfig } from './config.js';
 import { setPineconeClient, setupCoreServer, teardownServer } from './index.js';
 import {
   ServerContext,
+  createIsolatedContext,
   getDefaultServerContext,
   setDefaultServerContext,
 } from './server/server-context.js';
@@ -21,7 +24,10 @@ describe('setup guards (CodeRabbit PR #150)', () => {
   it('preserves injected client when setupAllianceServer receives context only', async () => {
     isolateFromDefaultContext();
     const mockClient = { query: vi.fn() };
-    const ctx = createTestServerContext({ client: mockClient as never });
+    const ctx = createIsolatedContext(
+      resolveAllianceConfig({ apiKey: 'sk-test', indexName: 'test-index' }),
+      { client: mockClient as never }
+    );
 
     await setupAllianceServer({ context: ctx });
 
@@ -30,7 +36,7 @@ describe('setup guards (CodeRabbit PR #150)', () => {
 
   it('installs Alliance defaults on context without config (no core lazy-resolve)', async () => {
     isolateFromDefaultContext();
-    const ctx = new ServerContext();
+    const ctx = new ServerContext<AllianceServerConfig>();
     expect(ctx.hasConfig()).toBe(false);
 
     vi.stubEnv('PINECONE_API_KEY', 'sk-alliance-default');

--- a/src/core/setup-multi-instance.test.ts
+++ b/src/core/setup-multi-instance.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveAllianceConfig } from '../alliance/config.js';
 import { setupAllianceServer } from '../alliance/setup.js';
+import { createIsolatedContext } from './server/server-context.js';
 import { setupCoreServer, teardownServer } from './setup.js';
 import {
   createTestServerContext,
@@ -21,7 +22,7 @@ describe('setup multi-instance (phase 4)', () => {
     const cfgA = resolveTestConfig({ apiKey: 'multi-setup-a' });
     const cfgB = resolveAllianceConfig({ apiKey: 'multi-setup-b', indexName: 'idx-b' });
     const ctxA = createTestServerContext({ config: cfgA });
-    const ctxB = createTestServerContext({ config: cfgB });
+    const ctxB = createIsolatedContext(cfgB);
 
     await expect(setupCoreServer({ context: ctxA })).resolves.toBeDefined();
     await expect(setupAllianceServer({ context: ctxB })).resolves.toBeDefined();
@@ -32,7 +33,7 @@ describe('setup multi-instance (phase 4)', () => {
     const cfgA = resolveTestConfig({ apiKey: 'url-iso-a' });
     const cfgB = resolveAllianceConfig({ apiKey: 'url-iso-b', indexName: 'idx-b' });
     const ctxA = createTestServerContext({ config: cfgA });
-    const ctxB = createTestServerContext({ config: cfgB });
+    const ctxB = createIsolatedContext(cfgB);
 
     await setupCoreServer({ context: ctxA });
     await setupAllianceServer({ context: ctxB });

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -109,6 +109,11 @@ function resolveSetupContext(opts: SetupCoreServerOptions): CoreServerContext {
         );
       }
       opts.context.setConfig(opts.config);
+    } else {
+      const stored = opts.context.getConfigIfSet();
+      if (stored) {
+        assertCoreServerConfig(stored);
+      }
     }
     installExplicitServerContext(opts.context);
     return opts.context;

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -7,6 +7,7 @@ import {
   peekDefaultServerContext,
   resolveDefaultServerContext,
   teardownDefaultServerContext,
+  type CoreServerContext,
   type ServerContext,
 } from './server/server-context.js';
 import { registerCountTool } from './server/tools/count-tool.js';
@@ -40,7 +41,7 @@ export function teardownServer(): void {
  */
 export type SetupCoreServerOptions = {
   config?: CoreServerConfig;
-  context?: ServerContext;
+  context?: CoreServerContext;
   /** MCP server instructions; defaults to {@link CORE_SERVER_INSTRUCTIONS}. */
   instructions?: string;
 };
@@ -82,7 +83,7 @@ function normalizeSetupCoreServerArgs(
   throw new TypeError('configOrOptions must be a CoreServerConfig or SetupCoreServerOptions');
 }
 
-function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
+function resolveSetupContext(opts: SetupCoreServerOptions): CoreServerContext {
   if (opts.context) {
     if (opts.config) {
       if (opts.context.hasInjectedClient()) {
@@ -114,15 +115,13 @@ function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
     return ctx;
   }
 
-  return resolveDefaultServerContext();
+  return resolveDefaultServerContext() as CoreServerContext;
 }
 
-export async function setupCoreServer(
-  configOrOptions?: CoreServerConfig | SetupCoreServerOptions,
-  legacyOptions?: Pick<SetupCoreServerOptions, 'instructions'>
+async function registerCoreToolSurface(
+  ctx: ServerContext,
+  instructions?: string
 ): Promise<ServerHandle> {
-  const opts = normalizeSetupCoreServerArgs(configOrOptions, legacyOptions);
-  const ctx = resolveSetupContext(opts);
   ctx.assertCanRegisterTools();
 
   const server = new McpServer(
@@ -131,7 +130,7 @@ export async function setupCoreServer(
       version: SERVER_VERSION,
     },
     {
-      instructions: opts.instructions ?? CORE_SERVER_INSTRUCTIONS,
+      instructions: instructions ?? CORE_SERVER_INSTRUCTIONS,
     }
   );
 
@@ -151,4 +150,25 @@ export async function setupCoreServer(
     await ctx[Symbol.asyncDispose]();
   };
   return handle;
+}
+
+/**
+ * Register core MCP tools on a pre-configured context (Alliance layer internal entry).
+ * Does not accept {@link AllianceServerConfig}; use {@link setupAllianceServer} instead.
+ */
+export async function setupCoreServerOnContext(
+  ctx: ServerContext,
+  instructions?: string
+): Promise<ServerHandle> {
+  installExplicitServerContext(ctx);
+  return registerCoreToolSurface(ctx, instructions);
+}
+
+export async function setupCoreServer(
+  configOrOptions?: CoreServerConfig | SetupCoreServerOptions,
+  legacyOptions?: Pick<SetupCoreServerOptions, 'instructions'>
+): Promise<ServerHandle> {
+  const opts = normalizeSetupCoreServerArgs(configOrOptions, legacyOptions);
+  const ctx = resolveSetupContext(opts);
+  return registerCoreToolSurface(ctx, opts.instructions);
 }

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CORE_SERVER_INSTRUCTIONS, SERVER_NAME, SERVER_VERSION } from '../constants.js';
-import type { ServerConfig } from './config.js';
+import type { CoreServerConfig, ServerConfigBase } from './config.js';
 import {
   createServer,
   installExplicitServerContext,
@@ -39,18 +39,18 @@ export function teardownServer(): void {
  * full Alliance tool surface (suggest-flow gate on by default).
  */
 export type SetupCoreServerOptions = {
-  config?: ServerConfig;
+  config?: CoreServerConfig;
   context?: ServerContext;
   /** MCP server instructions; defaults to {@link CORE_SERVER_INSTRUCTIONS}. */
   instructions?: string;
 };
 
-function isServerConfig(value: unknown): value is ServerConfig {
+function isServerConfig(value: unknown): value is CoreServerConfig {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as ServerConfig).apiKey === 'string' &&
-    typeof (value as ServerConfig).indexName === 'string'
+    typeof (value as ServerConfigBase).apiKey === 'string' &&
+    typeof (value as ServerConfigBase).indexName === 'string'
   );
 }
 
@@ -67,7 +67,7 @@ function isSetupCoreServerOptions(value: unknown): value is SetupCoreServerOptio
 }
 
 function normalizeSetupCoreServerArgs(
-  configOrOptions?: ServerConfig | SetupCoreServerOptions,
+  configOrOptions?: CoreServerConfig | SetupCoreServerOptions,
   legacyOptions?: Pick<SetupCoreServerOptions, 'instructions'>
 ): SetupCoreServerOptions {
   if (configOrOptions === undefined) {
@@ -79,7 +79,7 @@ function normalizeSetupCoreServerArgs(
   if (isSetupCoreServerOptions(configOrOptions)) {
     return { ...configOrOptions, ...legacyOptions };
   }
-  throw new TypeError('configOrOptions must be a ServerConfig or SetupCoreServerOptions');
+  throw new TypeError('configOrOptions must be a CoreServerConfig or SetupCoreServerOptions');
 }
 
 function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
@@ -118,7 +118,7 @@ function resolveSetupContext(opts: SetupCoreServerOptions): ServerContext {
 }
 
 export async function setupCoreServer(
-  configOrOptions?: ServerConfig | SetupCoreServerOptions,
+  configOrOptions?: CoreServerConfig | SetupCoreServerOptions,
   legacyOptions?: Pick<SetupCoreServerOptions, 'instructions'>
 ): Promise<ServerHandle> {
   const opts = normalizeSetupCoreServerArgs(configOrOptions, legacyOptions);

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CORE_SERVER_INSTRUCTIONS, SERVER_NAME, SERVER_VERSION } from '../constants.js';
 import type { CoreServerConfig, ServerConfigBase } from './config.js';
+import { getServerConfigLineage } from './config.js';
 import {
   createServer,
   installExplicitServerContext,
@@ -47,12 +48,23 @@ export type SetupCoreServerOptions = {
 };
 
 function isServerConfig(value: unknown): value is CoreServerConfig {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as ServerConfigBase).apiKey === 'string' &&
-    typeof (value as ServerConfigBase).indexName === 'string'
-  );
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const base = value as ServerConfigBase;
+  if (typeof base.apiKey !== 'string' || typeof base.indexName !== 'string') {
+    return false;
+  }
+  return getServerConfigLineage(base) === 'core';
+}
+
+function assertCoreServerConfig(config: ServerConfigBase): CoreServerConfig {
+  if (getServerConfigLineage(config) !== 'core') {
+    throw new TypeError(
+      'Expected CoreServerConfig. Use setupAllianceServer for Alliance-branded config.'
+    );
+  }
+  return config as CoreServerConfig;
 }
 
 function isSetupCoreServerOptions(value: unknown): value is SetupCoreServerOptions {
@@ -84,6 +96,10 @@ function normalizeSetupCoreServerArgs(
 }
 
 function resolveSetupContext(opts: SetupCoreServerOptions): CoreServerContext {
+  if (opts.config) {
+    assertCoreServerConfig(opts.config);
+  }
+
   if (opts.context) {
     if (opts.config) {
       if (opts.context.hasInjectedClient()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import * as dotenv from 'dotenv';
 import { parseCli, printHelp, printVersion } from './cli.js';
-import type { ServerConfig } from './core/config.js';
+import type { AllianceServerConfig } from './alliance/config.js';
 import { resolveAllianceConfig } from './alliance/config.js';
 import { PineconeClient } from './core/pinecone-client.js';
 import { createServer } from './core/server/server-context.js';
@@ -23,7 +23,7 @@ dotenv.config();
  * Build a config from CLI argv + environment, exiting fast on
  * --help, --version, or missing API key / index name.
  */
-function buildConfigOrExit(): ServerConfig {
+function buildConfigOrExit(): AllianceServerConfig {
   const parsed = parseCli();
   if (parsed.kind === 'help') {
     printHelp();

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,8 @@ export type PineconeMetadataValue = string | number | boolean | string[];
  *
  * `apiKey` and `indexName` are required via {@link resolveConfig} (env, CLI, or overrides).
  * `rerankModel` is optional — omit to disable reranking. Alliance {@link resolveAllianceConfig} supplies a default rerank model when unset.
- * Values are expected to come from a resolved `ServerConfig` — `PineconeClient`
+ * Values are expected to come from a resolved {@link ServerConfigBase} (or branded
+ * {@link CoreServerConfig} / {@link AllianceServerConfig}) — `PineconeClient`
  * does not read `process.env` directly.
  */
 export interface PineconeClientConfig {


### PR DESCRIPTION
## Summary

- Split the single `ServerConfig` type into `ServerConfigBase` plus branded `CoreServerConfig` and `AllianceServerConfig` using `unique symbol` brands
- Narrow `resolveConfig()` / `setupCoreServer()` to core config and `resolveAllianceConfig()` / `setupAllianceServer()` to Alliance config so passing Alliance config into core setup is a compile-time error
- Refactor `setupAllianceServer` to hand config to core setup via context only (`setConfig` / `createServer`), avoiding branded-type conflicts at the delegation boundary
- Add `src/__tests__/config-branding.compile-test.ts` with `@ts-expect-error` guards; exclude `dist/__tests__/` from npm via `.npmignore`
- Update alliance examples to use `resolveAllianceConfig`

## Motivation

`resolveConfig()` and `resolveAllianceConfig()` returned structurally identical configs with different defaults (suggest-flow gate, index, rerank). Passing an Alliance config to `setupCoreServer()` compiled cleanly but changed runtime behavior silently.

## Test plan

- [x] `npm run typecheck` (includes compile-time branding misuse test)
- [x] `npm run test` (294 tests)
- [x] `npm run ci`

## Related issue

- Close https://github.com/cppalliance/pinecone-read-only-mcp-typescript/issues/172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branded configuration and context types to clearly separate core vs Alliance setup paths.
  * Improved server setup ergonomics with core tool registration on an existing context, plus clearer Alliance configuration typing.
* **Bug Fixes**
  * Fixed package publishing to exclude bundled test directories.
  * Updated Alliance demos to use the Alliance configuration resolver.
* **Tests**
  * Added compile-time checks to prevent mixing core/Alliance configs and contexts.
* **Documentation**
  * Updated the unreleased migration guide with branded-type usage and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->