### PR TITLE
Keep test-only source out of the published build

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "scripts": {
     "clean": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true});\"",
-    "build": "npm run clean && npx tsc",
-    "build:watch": "tsc --watch",
+    "build": "npm run clean && npx tsc -p tsconfig.build.json",
+    "build:watch": "tsc -p tsconfig.build.json --watch",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "smoke": "npm run build && node dist/index.js --help",

--- a/src/__tests__/build-excludes-test-code.test.ts
+++ b/src/__tests__/build-excludes-test-code.test.ts
@@ -30,6 +30,7 @@ function buildProgramSrcFiles(): string[] {
     .filter((rel) => rel.startsWith('src/'));
 }
 
+// Mirrors tsconfig.build.json's exclude — add any new test-only suffix to both.
 const TEST_CODE = [
   /\.test\.ts$/,
   /\.compile-test\.ts$/,

--- a/src/__tests__/build-excludes-test-code.test.ts
+++ b/src/__tests__/build-excludes-test-code.test.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards against test-only source leaking into the published build (#217).
+ *
+ * The stale `tsconfig.json` exclude pointed at a path that no longer matched
+ * `test-helpers.ts`, so it (and the `.compile-test.ts` brand guards) shipped
+ * into `dist/`. `tsconfig.build.json` now excludes test code by pattern; this
+ * test asks tsc which files that config would compile and fails if any test
+ * module is still in the program.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const tscEntry = path.join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc');
+
+function buildProgramSrcFiles(): string[] {
+  const out = execFileSync(
+    process.execPath,
+    [tscEntry, '-p', 'tsconfig.build.json', '--listFilesOnly'],
+    { cwd: repoRoot, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
+  );
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((abs) => path.relative(repoRoot, abs).split(path.sep).join('/'))
+    .filter((rel) => rel.startsWith('src/'));
+}
+
+const TEST_CODE = [
+  /\.test\.ts$/,
+  /\.compile-test\.ts$/,
+  /(^|\/)test-helpers\.ts$/,
+  /(^|\/)__tests__\//,
+];
+
+describe('build output excludes test code (#217)', () => {
+  it('the build tsconfig compiles no test-only modules from src', () => {
+    const files = buildProgramSrcFiles();
+    // Guard against a vacuous pass: if the build config ever compiled nothing,
+    // `leaked` would be empty while the real build is broken.
+    expect(files).toContain('src/index.ts');
+    const leaked = files.filter((f) => TEST_CODE.some((re) => re.test(f)));
+    expect(leaked).toEqual([]);
+  }, 60_000);
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  // New test-only suffixes must also go in TEST_CODE in
+  // src/__tests__/build-excludes-test-code.test.ts, which guards this list.
   "exclude": [
     "node_modules",
     "dist",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.compile-test.ts",
+    "**/test-helpers.ts",
+    "**/__tests__/**"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "typeRoots": ["./node_modules/@types"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/server/tools/test-helpers.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
Closes #217

The tsconfig exclude pointed at a stale path (`src/server/tools/test-helpers.ts`), but the file lives at `src/core/server/tools/test-helpers.ts`. Because the glob never matched, `tsc` compiled it into `dist/`. Scoping that out surfaced a second leak: `config-branding.compile-test.ts` also shipped, since its `-test.ts` name is not caught by `**/*.test.ts`.

## What changed

Split the build config from the typecheck config. `tsconfig.build.json` excludes all test code by pattern (`**/*.test.ts`, `**/*.compile-test.ts`, `**/test-helpers.ts`, `**/__tests__/**`), so it stays correct if files move. The base `tsconfig.json` still type-checks the `.compile-test.ts` brand guards, which is their whole purpose. `build` and `build:watch` now run `-p tsconfig.build.json`.

Added a regression test that asks tsc which files the build config compiles (`--listFilesOnly`) and fails if any test module survives. It also asserts a real source file is present so it cannot pass on an empty program.

## Verification

- Clean build: 50 source JS files, zero test artifacts in `dist/`.
- Typecheck still covers the compile-test guards.
- Lint, format:check, and the full suite (367 tests) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build Improvements**
  - Updated production builds to use a dedicated TypeScript build configuration and clean `dist` before compiling.
  - Ensured test-only files and development helpers are excluded from production build output.
  - Updated build watch mode to track the production build TypeScript configuration.

- **Tests**
  - Added an automated check that verifies test-only modules are not compiled into the production build, while confirming the main app entry point is included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->