### PR TITLE
SDK-shape conformance test for SearchableIndex

### DIFF
--- a/src/core/pinecone/searchable-index-conformance.test.ts
+++ b/src/core/pinecone/searchable-index-conformance.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { Pinecone } from '@pinecone-database/pinecone';
+
+/**
+ * SDK-shape conformance guard for SearchableIndex (#220).
+ *
+ * `indexes.ts` force-casts `pc.index(...)` to `SearchableIndex` with `as unknown as`,
+ * which erases type checking, and the other tests only mock our own interface. So
+ * nothing verifies the real SDK index still provides the members the code calls. If a
+ * Pinecone SDK bump renames or removes one, it slips past the compiler and fails at
+ * runtime in production. This asserts those members exist on a real SDK index, so a
+ * drift fails here loudly instead.
+ *
+ * A compile-time assertion was tried but the SDK types the index too loosely to catch
+ * drift, so this is a runtime existence check. `pc.index()` returns a handle
+ * synchronously with no network call, so it needs no live Pinecone.
+ */
+describe('SearchableIndex SDK conformance (#220)', () => {
+  // Members the code calls on the index through SearchableIndex (indexes.ts / search.ts).
+  const REQUIRED_MEMBERS = ['describeIndexStats', 'namespace', 'searchRecords', 'query'] as const;
+
+  const index = new Pinecone({ apiKey: 'pc-conformance-test' }).index(
+    'conformance-test'
+  ) as unknown as Record<string, unknown>;
+
+  it.each(REQUIRED_MEMBERS)('the SDK index exposes %s()', (method) => {
+    expect(typeof index[method]).toBe('function');
+  });
+});

--- a/src/core/pinecone/searchable-index-conformance.test.ts
+++ b/src/core/pinecone/searchable-index-conformance.test.ts
@@ -16,14 +16,28 @@ import { Pinecone } from '@pinecone-database/pinecone';
  * synchronously with no network call, so it needs no live Pinecone.
  */
 describe('SearchableIndex SDK conformance (#220)', () => {
-  // Members the code calls on the index through SearchableIndex (indexes.ts / search.ts).
-  const REQUIRED_MEMBERS = ['describeIndexStats', 'namespace', 'searchRecords', 'query'] as const;
-
   const index = new Pinecone({ apiKey: 'pc-conformance-test' }).index(
     'conformance-test'
   ) as unknown as Record<string, unknown>;
 
-  it.each(REQUIRED_MEMBERS)('the SDK index exposes %s()', (method) => {
-    expect(typeof index[method]).toBe('function');
-  });
+  // Called on the top-level index: indexes.ts uses describeIndexStats() and
+  // namespace(), and search.ts uses searchRecords() on the index fallback branch.
+  it.each(['describeIndexStats', 'namespace', 'searchRecords'] as const)(
+    'the SDK index exposes %s()',
+    (method) => {
+      expect(typeof index[method]).toBe('function');
+    }
+  );
+
+  // Called on the namespace handle from index.namespace(ns): indexes.ts does
+  // namespace(ns).query(...) and search.ts does namespace(ns).searchRecords(...).
+  const namespaceHandle = (index.namespace as (name: string) => Record<string, unknown>)(
+    'conformance-test'
+  );
+  it.each(['query', 'searchRecords'] as const)(
+    'the SDK namespace handle exposes %s()',
+    (method) => {
+      expect(typeof namespaceHandle[method]).toBe('function');
+    }
+  );
 });


### PR DESCRIPTION
Closes #220.

`SearchableIndex` (`src/types.ts`) is a hand-written interface, and `src/core/pinecone/indexes.ts` force-casts the real SDK index onto it with `as unknown as SearchableIndex`, which erases type checking. The existing tests only mock our own interface, so nothing verifies the SDK index actually provides the members the code calls. A Pinecone SDK bump that renames or removes one would slip past the compiler and fail at runtime.

## What this adds

A conformance test that constructs a real SDK index handle (offline — `pc.index()` returns a handle with no network call) and asserts the members the code relies on exist: `describeIndexStats`, `namespace`, `searchRecords`, `query`. A rename/removal in a future SDK fails this test loudly instead of at runtime. Verified against SDK 8.0.0, and confirmed a renamed member fails the test.

`search` is intentionally not asserted — the SDK `Index` has no bare `search()`; that call site in `search.ts` is a guarded fallback.

## Note

I tried a compile-time assertion so signature drift would also fail at build, but the SDK types the index too loosely for it to catch drift without passing vacuously (a negative check caught two formulations doing exactly that), so this is a runtime existence check rather than ship a guard that looks like it verifies something but does not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a runtime compatibility/conformance check for the Pinecone search index interface.
  * The test verifies key index and namespace operations are present and will flag breaking SDK shape changes early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->