### PR TITLE
Wire request timeout and 429/5xx retry onto Pinecone I/O hot path

### DIFF
--- a/src/core/pinecone-client.test.ts
+++ b/src/core/pinecone-client.test.ts
@@ -21,10 +21,7 @@ function stubPineconeClient(client: PineconeClient): PineconeClientMethodStubs {
   return client as unknown as PineconeClientMethodStubs;
 }
 
-function stubDualLegSearchFailure(
-  testClient: PineconeClientMethodStubs,
-  searchError: Error
-): void {
+function stubDualLegSearchFailure(testClient: PineconeClientMethodStubs, searchError: Error): void {
   testClient.ensureIndexes = async () => ({
     denseIndex: {} as SearchableIndex,
     sparseIndex: {} as SearchableIndex,

--- a/src/core/pinecone-client.test.ts
+++ b/src/core/pinecone-client.test.ts
@@ -21,6 +21,19 @@ function stubPineconeClient(client: PineconeClient): PineconeClientMethodStubs {
   return client as unknown as PineconeClientMethodStubs;
 }
 
+function stubDualLegSearchFailure(
+  testClient: PineconeClientMethodStubs,
+  searchError: Error
+): void {
+  testClient.ensureIndexes = async () => ({
+    denseIndex: {} as SearchableIndex,
+    sparseIndex: {} as SearchableIndex,
+  });
+  testClient.searchIndex = async () => {
+    throw searchError;
+  };
+}
+
 describe('PineconeClient', () => {
   let client: PineconeClient;
 
@@ -147,14 +160,7 @@ describe('PineconeClient', () => {
 
     it('should throw when both dense and sparse searches fail', async () => {
       const testClient = stubPineconeClient(client);
-
-      testClient.ensureIndexes = async () => ({
-        denseIndex: {} as SearchableIndex,
-        sparseIndex: {} as SearchableIndex,
-      });
-      testClient.searchIndex = async () => {
-        throw new Error('index failure');
-      };
+      stubDualLegSearchFailure(testClient, new Error('index failure'));
 
       await expect(
         client.query({
@@ -164,6 +170,23 @@ describe('PineconeClient', () => {
           useReranking: false,
         })
       ).rejects.toThrow('Hybrid search failed: both dense and sparse index searches failed.');
+    });
+
+    it('propagates app timeout when both dense and sparse searches fail', async () => {
+      const testClient = stubPineconeClient(client);
+      stubDualLegSearchFailure(
+        testClient,
+        new Error('Timeout after 50ms while waiting for search')
+      );
+
+      await expect(
+        client.query({
+          query: 'hybrid search',
+          namespace: 'test',
+          topK: 5,
+          useReranking: false,
+        })
+      ).rejects.toThrow('Timeout after 50ms while waiting for search');
     });
   });
 

--- a/src/core/pinecone-client.test.ts
+++ b/src/core/pinecone-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { PineconeClient } from './pinecone-client.js';
 import { resolveConfig } from './config.js';
 import type { SearchableIndex, PineconeHit } from '../types.js';
@@ -30,6 +30,10 @@ describe('PineconeClient', () => {
       indexName: 'test-index',
       rerankModel: 'test-model',
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('constructor', () => {
@@ -441,6 +445,27 @@ describe('PineconeClient', () => {
       await expect(client.keywordSearch({ query: '   ', namespace: 'n' })).rejects.toThrow(
         'Query cannot be empty'
       );
+    });
+
+    it('passes configured requestTimeoutMs to search call sites', async () => {
+      vi.useFakeTimers();
+      const timeoutClient = new PineconeClient({
+        apiKey: 'test-api-key',
+        indexName: 'test-index',
+        requestTimeoutMs: 50,
+      });
+      const testClient = stubPineconeClient(timeoutClient);
+      const search = vi.fn(() => new Promise(() => {}));
+      const sparseRef = { search } as SearchableIndex;
+      testClient.ensureIndexes = async () => ({
+        denseIndex: {} as SearchableIndex,
+        sparseIndex: sparseRef,
+      });
+
+      const p = timeoutClient.keywordSearch({ query: 'q', namespace: 'n' });
+      const assertion = expect(p).rejects.toThrow(/Timeout after 50ms while waiting for search/);
+      await vi.advanceTimersByTimeAsync(50);
+      await assertion;
     });
 
     it('searches sparse index only and maps hits', async () => {

--- a/src/core/pinecone-client.ts
+++ b/src/core/pinecone-client.ts
@@ -105,7 +105,15 @@ export class PineconeClient {
     metadataFilter?: Record<string, unknown>,
     options?: { fields?: string[] }
   ): Promise<PineconeHit[]> {
-    return searchIndexImpl(index, query, topK, namespace, metadataFilter, options);
+    return searchIndexImpl(
+      index,
+      query,
+      topK,
+      namespace,
+      metadataFilter,
+      options,
+      this.indexSession.getRequestTimeoutMs()
+    );
   }
 
   async query(params: QueryParams): Promise<HybridQueryResult> {
@@ -179,7 +187,8 @@ export class PineconeClient {
         this.rerankModel,
         query,
         mergedResults,
-        topK
+        topK,
+        this.indexSession.getRequestTimeoutMs()
       );
       documents = rerankOut.results;
       degraded = rerankOut.degraded;

--- a/src/core/pinecone-client.ts
+++ b/src/core/pinecone-client.ts
@@ -25,6 +25,7 @@ import {
   sliceMergedHitsToSearchResults,
 } from './pinecone/search.js';
 import { rerankResults as rerankResultsImpl } from './pinecone/rerank.js';
+import { isAppTimeoutError } from './server/retry.js';
 
 export class PineconeClient {
   private readonly rerankModel: string | undefined;
@@ -157,6 +158,8 @@ export class PineconeClient {
       logError('Sparse index search failed', sparseResult.reason);
     }
     if (denseResult.status === 'rejected' && sparseResult.status === 'rejected') {
+      if (isAppTimeoutError(denseResult.reason)) throw denseResult.reason;
+      if (isAppTimeoutError(sparseResult.reason)) throw sparseResult.reason;
       throw new Error('Hybrid search failed: both dense and sparse index searches failed.');
     }
 

--- a/src/core/pinecone/indexes.test.ts
+++ b/src/core/pinecone/indexes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { PineconeIndexSession } from './indexes.js';
 import type { SearchableIndex } from '../../types.js';
 
@@ -28,6 +28,27 @@ class ThrowingEnsureSession extends PineconeIndexSession {
     throw new Error('no client');
   }
 }
+
+/** Session with a short timeout for fake-timer I/O deadline tests. */
+class TimeoutIndexSession extends PineconeIndexSession {
+  constructor(
+    private readonly pair: { dense: SearchableIndex; sparse: SearchableIndex },
+    requestTimeoutMs = 50
+  ) {
+    super('test-api-key', 'test-index', undefined, requestTimeoutMs);
+  }
+
+  override async ensureIndexes(): Promise<{
+    denseIndex: SearchableIndex;
+    sparseIndex: SearchableIndex;
+  }> {
+    return { denseIndex: this.pair.dense, sparseIndex: this.pair.sparse };
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('PineconeIndexSession', () => {
   describe('listNamespacesFromKeywordIndex', () => {
@@ -65,6 +86,46 @@ describe('PineconeIndexSession', () => {
       if (!result.ok) {
         expect(result.error).toContain('stats unavailable');
       }
+    });
+
+    it('retries describeIndexStats on 503 then succeeds', async () => {
+      let n = 0;
+      const sparse = {
+        describeIndexStats: vi.fn().mockImplementation(async () => {
+          n++;
+          if (n < 2) throw new Error('HTTP 503');
+          return { namespaces: { papers: { recordCount: 7 } } };
+        }),
+      } as unknown as SearchableIndex;
+      const session = new PineconeIndexSessionTestDouble({
+        dense: {} as SearchableIndex,
+        sparse,
+      });
+
+      const result = await session.listNamespacesFromKeywordIndex();
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.namespaces).toEqual([{ namespace: 'papers', recordCount: 7 }]);
+      }
+      expect(sparse.describeIndexStats).toHaveBeenCalledTimes(2);
+    });
+
+    it('times out describeIndexStats at requestTimeoutMs', async () => {
+      vi.useFakeTimers();
+      const sparse = {
+        describeIndexStats: vi.fn(() => new Promise(() => {})),
+      } as unknown as SearchableIndex;
+      const session = new TimeoutIndexSession({ dense: {} as SearchableIndex, sparse });
+      const p = session.listNamespacesFromKeywordIndex();
+      const assertion = expect(p).resolves.toMatchObject({
+        ok: false,
+        error: expect.stringMatching(
+          /Timeout after 50ms while waiting for describeIndexStats-sparse/
+        ),
+      });
+      await vi.advanceTimersByTimeAsync(50);
+      await assertion;
     });
   });
 
@@ -139,6 +200,33 @@ describe('PineconeIndexSession', () => {
       expect(rows.namespaces[0]?.metadata['emptyArr']).toBe('array');
       expect(rows.namespaces[0]?.metadata['nested']).toBe('object');
       expect(rows.namespaces[0]?.schema_source).toBe('sampled');
+    });
+
+    it('times out metadata sampling at requestTimeoutMs', async () => {
+      vi.useFakeTimers();
+      const dense = {
+        describeIndexStats: vi.fn().mockResolvedValue({
+          namespaces: { ns1: { recordCount: 2 } },
+          dimension: 4,
+        }),
+        namespace: vi.fn().mockReturnValue({
+          query: vi.fn(() => new Promise(() => {})),
+        }),
+      } as unknown as SearchableIndex;
+      const session = new TimeoutIndexSession({ dense, sparse: {} as SearchableIndex });
+      const p = session.listNamespacesWithMetadata();
+      const assertion = expect(p).resolves.toMatchObject({
+        namespaces: [
+          {
+            namespace: 'ns1',
+            recordCount: 2,
+            metadata: {},
+            schema_source: 'sampled',
+          },
+        ],
+      });
+      await vi.advanceTimersByTimeAsync(50);
+      await assertion;
     });
 
     it('uses declared schema and skips sampling when declaredSchemas provides one', async () => {

--- a/src/core/pinecone/indexes.test.ts
+++ b/src/core/pinecone/indexes.test.ts
@@ -50,6 +50,39 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+/** Mock describeIndexStats that fails when the SDK method is invoked detached. */
+function makeThisSensitiveIndex(
+  result: {
+    namespaces?: Record<string, { recordCount?: number }>;
+    dimension?: number;
+  } = {}
+): SearchableIndex {
+  const index = {
+    describeIndexStats() {
+      if (this !== index) {
+        throw new TypeError('detached SDK method: wrong this binding');
+      }
+      return Promise.resolve(result);
+    },
+  };
+  return index as unknown as SearchableIndex;
+}
+
+/** Mock namespace().query that fails when the SDK method is invoked detached. */
+function makeThisSensitiveNamespaceHandle(
+  matches: Array<{ metadata?: Record<string, unknown> }> = []
+) {
+  const handle = {
+    query() {
+      if (this !== handle) {
+        throw new TypeError('detached SDK method: wrong this binding');
+      }
+      return Promise.resolve({ matches });
+    },
+  };
+  return handle;
+}
+
 describe('PineconeIndexSession', () => {
   describe('listNamespacesFromKeywordIndex', () => {
     it('returns namespace rows when describeIndexStats succeeds', async () => {
@@ -111,6 +144,23 @@ describe('PineconeIndexSession', () => {
       expect(sparse.describeIndexStats).toHaveBeenCalledTimes(2);
     });
 
+    it('invokes describeIndexStats on the sparse index receiver through runIo', async () => {
+      const sparse = makeThisSensitiveIndex({
+        namespaces: { papers: { recordCount: 42 } },
+      });
+      const session = new PineconeIndexSessionTestDouble({
+        dense: {} as SearchableIndex,
+        sparse,
+      });
+
+      const result = await session.listNamespacesFromKeywordIndex();
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.namespaces).toEqual([{ namespace: 'papers', recordCount: 42 }]);
+      }
+    });
+
     it('times out describeIndexStats at requestTimeoutMs', async () => {
       vi.useFakeTimers();
       const sparse = {
@@ -163,6 +213,28 @@ describe('PineconeIndexSession', () => {
         recordCount: 0,
         metadata: {},
         schema_source: 'sampled',
+      });
+    });
+
+    it('invokes namespace().query on the namespace receiver through runIo when sampling', async () => {
+      const nsHandle = makeThisSensitiveNamespaceHandle([
+        { metadata: { title: 'T', tags: ['a'] } },
+      ]);
+      const dense = makeThisSensitiveIndex({
+        namespaces: { ns1: { recordCount: 2 } },
+        dimension: 4,
+      }) as SearchableIndex & { namespace: (name: string) => typeof nsHandle };
+      dense.namespace = () => nsHandle;
+      const session = new PineconeIndexSessionTestDouble({
+        dense,
+        sparse: {} as SearchableIndex,
+      });
+
+      const rows = await session.listNamespacesWithMetadata();
+      expect(rows.namespaces).toHaveLength(1);
+      expect(rows.namespaces[0]?.metadata).toMatchObject({
+        title: 'string',
+        tags: 'string[]',
       });
     });
 
@@ -323,6 +395,16 @@ describe('PineconeIndexSession', () => {
   });
 
   describe('checkIndexes', () => {
+    it('invokes describeIndexStats on dense and sparse receivers through runIo', async () => {
+      const dense = makeThisSensitiveIndex();
+      const sparse = makeThisSensitiveIndex();
+      const session = new PineconeIndexSessionTestDouble({ dense, sparse });
+
+      const result = await session.checkIndexes();
+      expect(result.ok).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
     it('returns ok when describeIndexStats succeeds for dense and sparse', async () => {
       const dense = {
         describeIndexStats: vi.fn().mockResolvedValue({}),

--- a/src/core/pinecone/indexes.test.ts
+++ b/src/core/pinecone/indexes.test.ts
@@ -436,5 +436,31 @@ describe('PineconeIndexSession', () => {
         /Timeout after 50ms while waiting for fetchRecordFields/
       );
     });
+
+    it('retries fetch on 503 then succeeds', async () => {
+      let n = 0;
+      class RetryFetchSession extends PineconeIndexSession {
+        override ensureClient() {
+          return {
+            index: () => ({
+              fetch: vi.fn().mockImplementation(async () => {
+                n++;
+                if (n < 2) throw new Error('HTTP 503');
+                return {
+                  records: {
+                    schema_manifest: { metadata: { chunk_text: '{"ok":true}' } },
+                  },
+                };
+              }),
+            }),
+          } as never;
+        }
+      }
+
+      const session = new RetryFetchSession();
+      const fields = await session.fetchRecordFields('_mcp_config', 'schema_manifest');
+      expect(fields?.chunk_text).toBe('{"ok":true}');
+      expect(n).toBe(2);
+    });
   });
 });

--- a/src/core/pinecone/indexes.ts
+++ b/src/core/pinecone/indexes.ts
@@ -4,7 +4,7 @@
 
 import { Pinecone } from '@pinecone-database/pinecone';
 import { DEFAULT_REQUEST_TIMEOUT_MS } from '../config.js';
-import { withTimeout } from '../server/retry.js';
+import { runWithPolicy } from '../server/retry.js';
 import { error as logError, info as logInfo } from '../../logger.js';
 import type {
   KeywordIndexNamespacesResult,
@@ -57,6 +57,14 @@ export class PineconeIndexSession {
     return this.sparseIndexName ?? `${this.indexName}-sparse`;
   }
 
+  getRequestTimeoutMs(): number {
+    return this.requestTimeoutMs;
+  }
+
+  private runIo<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    return runWithPolicy(() => fn(), { timeoutMs: this.requestTimeoutMs, label });
+  }
+
   /** Ensure Pinecone client is initialized */
   ensureClient(): Pinecone {
     if (!this.pc) {
@@ -103,8 +111,9 @@ export class PineconeIndexSession {
   async listNamespacesFromKeywordIndex(): Promise<KeywordIndexNamespacesResult> {
     try {
       const { sparseIndex } = await this.ensureIndexes();
-      const stats = sparseIndex.describeIndexStats
-        ? await sparseIndex.describeIndexStats()
+      const describeStats = sparseIndex.describeIndexStats;
+      const stats = describeStats
+        ? await this.runIo('describeIndexStats-sparse', () => describeStats())
         : undefined;
       const namespaces = stats?.namespaces ?? {};
       const rows = Object.entries(namespaces).map(([namespace, info]) => ({
@@ -134,8 +143,9 @@ export class PineconeIndexSession {
       const { denseIndex } = await this.ensureIndexes();
 
       // Get index stats to find namespaces
-      const stats = denseIndex.describeIndexStats
-        ? await denseIndex.describeIndexStats()
+      const describeStats = denseIndex.describeIndexStats;
+      const stats = describeStats
+        ? await this.runIo('describeIndexStats-dense', () => describeStats())
         : undefined;
       const namespaces = stats?.namespaces ? Object.keys(stats.namespaces) : [];
       const liveSet = new Set(namespaces);
@@ -174,13 +184,16 @@ export class PineconeIndexSession {
             if (recordCount > 0 && denseIndex.namespace) {
               try {
                 const nsObj: NamespaceHandle = denseIndex.namespace(ns);
+                const queryFn = nsObj.query;
                 const sampleQuery =
-                  typeof nsObj.query === 'function'
-                    ? await nsObj.query({
-                        topK: 5,
-                        vector: Array(stats?.dimension ?? 1536).fill(0),
-                        includeMetadata: true,
-                      })
+                  typeof queryFn === 'function'
+                    ? await this.runIo('sampleNamespaceMetadata', () =>
+                        queryFn({
+                          topK: 5,
+                          vector: Array(stats?.dimension ?? 1536).fill(0),
+                          includeMetadata: true,
+                        })
+                      )
                     : { matches: undefined };
 
                 // Collect unique metadata fields and infer types (including string[])
@@ -238,26 +251,23 @@ export class PineconeIndexSession {
    * may appear on the record or inside metadata.
    */
   async fetchRecordFields(namespace: string, id: string): Promise<Record<string, unknown> | null> {
-    return withTimeout(
-      async (_signal) => {
-        const pc = this.ensureClient();
-        const response = await pc.index(this.indexName).fetch({ ids: [id], namespace });
-        const record = response.records?.[id] as
-          (Record<string, unknown> & { metadata?: Record<string, unknown> }) | undefined;
-        if (!record) {
-          return null;
+    return this.runIo('fetchRecordFields', async () => {
+      const pc = this.ensureClient();
+      const response = await pc.index(this.indexName).fetch({ ids: [id], namespace });
+      const record = response.records?.[id] as
+        (Record<string, unknown> & { metadata?: Record<string, unknown> }) | undefined;
+      if (!record) {
+        return null;
+      }
+      const metadata = record.metadata ?? {};
+      const merged: Record<string, unknown> = { ...metadata };
+      for (const [k, v] of Object.entries(record)) {
+        if (k !== 'metadata' && k !== 'values' && k !== 'sparseValues' && !(k in merged)) {
+          merged[k] = v;
         }
-        const metadata = record.metadata ?? {};
-        const merged: Record<string, unknown> = { ...metadata };
-        for (const [k, v] of Object.entries(record)) {
-          if (k !== 'metadata' && k !== 'values' && k !== 'sparseValues' && !(k in merged)) {
-            merged[k] = v;
-          }
-        }
-        return merged;
-      },
-      { timeoutMs: this.requestTimeoutMs, label: 'fetchRecordFields' }
-    );
+      }
+      return merged;
+    });
   }
 
   /**
@@ -277,7 +287,8 @@ export class PineconeIndexSession {
         );
       } else {
         try {
-          await denseIndex.describeIndexStats();
+          const describeDense = denseIndex.describeIndexStats;
+          await this.runIo('describeIndexStats-dense', () => describeDense());
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           errors.push(`Dense index "${denseName}": ${msg}`);
@@ -290,7 +301,8 @@ export class PineconeIndexSession {
         );
       } else {
         try {
-          await sparseIndex.describeIndexStats();
+          const describeSparse = sparseIndex.describeIndexStats;
+          await this.runIo('describeIndexStats-sparse', () => describeSparse());
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           errors.push(`Sparse index "${sparseName}": ${msg}`);

--- a/src/core/pinecone/indexes.ts
+++ b/src/core/pinecone/indexes.ts
@@ -118,10 +118,11 @@ export class PineconeIndexSession {
   async listNamespacesFromKeywordIndex(): Promise<KeywordIndexNamespacesResult> {
     try {
       const { sparseIndex } = await this.ensureIndexes();
-      const describeStats = sparseIndex.describeIndexStats;
-      const stats = describeStats
-        ? await this.runIo('describeIndexStats-sparse', () => describeStats())
-        : undefined;
+      // SDK methods must be invoked on the index receiver inside runIo, not detached.
+      const stats =
+        typeof sparseIndex.describeIndexStats === 'function'
+          ? await this.runIo('describeIndexStats-sparse', () => sparseIndex.describeIndexStats!())
+          : undefined;
       const namespaces = stats?.namespaces ?? {};
       const rows = Object.entries(namespaces).map(([namespace, info]) => ({
         namespace,
@@ -150,10 +151,10 @@ export class PineconeIndexSession {
       const { denseIndex } = await this.ensureIndexes();
 
       // Get index stats to find namespaces
-      const describeStats = denseIndex.describeIndexStats;
-      const stats = describeStats
-        ? await this.runIo('describeIndexStats-dense', () => describeStats())
-        : undefined;
+      const stats =
+        typeof denseIndex.describeIndexStats === 'function'
+          ? await this.runIo('describeIndexStats-dense', () => denseIndex.describeIndexStats!())
+          : undefined;
       const namespaces = stats?.namespaces ? Object.keys(stats.namespaces) : [];
       const liveSet = new Set(namespaces);
 
@@ -191,11 +192,10 @@ export class PineconeIndexSession {
             if (recordCount > 0 && denseIndex.namespace) {
               try {
                 const nsObj: NamespaceHandle = denseIndex.namespace(ns);
-                const queryFn = nsObj.query;
                 const sampleQuery =
-                  typeof queryFn === 'function'
+                  typeof nsObj.query === 'function'
                     ? await this.runIo('sampleNamespaceMetadata', () =>
-                        queryFn({
+                        nsObj.query!({
                           topK: 5,
                           vector: Array(stats?.dimension ?? 1536).fill(0),
                           includeMetadata: true,
@@ -294,10 +294,9 @@ export class PineconeIndexSession {
         );
       } else {
         try {
-          const describeDense = denseIndex.describeIndexStats;
           await this.runIo(
             'describeIndexStats-dense',
-            () => describeDense(),
+            () => denseIndex.describeIndexStats!(),
             CHECK_INDEXES_IO_POLICY
           );
         } catch (err) {
@@ -312,10 +311,9 @@ export class PineconeIndexSession {
         );
       } else {
         try {
-          const describeSparse = sparseIndex.describeIndexStats;
           await this.runIo(
             'describeIndexStats-sparse',
-            () => describeSparse(),
+            () => sparseIndex.describeIndexStats!(),
             CHECK_INDEXES_IO_POLICY
           );
         } catch (err) {

--- a/src/core/pinecone/indexes.ts
+++ b/src/core/pinecone/indexes.ts
@@ -13,10 +13,7 @@ import type {
 } from '../../types.js';
 
 /** Startup probe: fail fast on unreachable indexes instead of retrying. */
-const CHECK_INDEXES_IO_POLICY = { retries: 0 } as const satisfies Pick<
-  PolicyOptions,
-  'retries'
->;
+const CHECK_INDEXES_IO_POLICY = { retries: 0 } as const satisfies Pick<PolicyOptions, 'retries'>;
 
 function inferMetadataFieldType(value: unknown): string {
   if (value === null || value === undefined) {
@@ -298,7 +295,11 @@ export class PineconeIndexSession {
       } else {
         try {
           const describeDense = denseIndex.describeIndexStats;
-          await this.runIo('describeIndexStats-dense', () => describeDense(), CHECK_INDEXES_IO_POLICY);
+          await this.runIo(
+            'describeIndexStats-dense',
+            () => describeDense(),
+            CHECK_INDEXES_IO_POLICY
+          );
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           errors.push(`Dense index "${denseName}": ${msg}`);
@@ -312,7 +313,11 @@ export class PineconeIndexSession {
       } else {
         try {
           const describeSparse = sparseIndex.describeIndexStats;
-          await this.runIo('describeIndexStats-sparse', () => describeSparse(), CHECK_INDEXES_IO_POLICY);
+          await this.runIo(
+            'describeIndexStats-sparse',
+            () => describeSparse(),
+            CHECK_INDEXES_IO_POLICY
+          );
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           errors.push(`Sparse index "${sparseName}": ${msg}`);

--- a/src/core/pinecone/indexes.ts
+++ b/src/core/pinecone/indexes.ts
@@ -4,13 +4,19 @@
 
 import { Pinecone } from '@pinecone-database/pinecone';
 import { DEFAULT_REQUEST_TIMEOUT_MS } from '../config.js';
-import { runWithPolicy } from '../server/retry.js';
+import { runWithPolicy, type PolicyOptions } from '../server/retry.js';
 import { error as logError, info as logInfo } from '../../logger.js';
 import type {
   KeywordIndexNamespacesResult,
   NamespaceHandle,
   SearchableIndex,
 } from '../../types.js';
+
+/** Startup probe: fail fast on unreachable indexes instead of retrying. */
+const CHECK_INDEXES_IO_POLICY = { retries: 0 } as const satisfies Pick<
+  PolicyOptions,
+  'retries'
+>;
 
 function inferMetadataFieldType(value: unknown): string {
   if (value === null || value === undefined) {
@@ -61,8 +67,12 @@ export class PineconeIndexSession {
     return this.requestTimeoutMs;
   }
 
-  private runIo<T>(label: string, fn: () => Promise<T>): Promise<T> {
-    return runWithPolicy(() => fn(), { timeoutMs: this.requestTimeoutMs, label });
+  private runIo<T>(
+    label: string,
+    fn: () => Promise<T>,
+    policy?: Pick<PolicyOptions, 'retries' | 'backoffMs'>
+  ): Promise<T> {
+    return runWithPolicy(() => fn(), { timeoutMs: this.requestTimeoutMs, label, ...policy });
   }
 
   /** Ensure Pinecone client is initialized */
@@ -288,7 +298,7 @@ export class PineconeIndexSession {
       } else {
         try {
           const describeDense = denseIndex.describeIndexStats;
-          await this.runIo('describeIndexStats-dense', () => describeDense());
+          await this.runIo('describeIndexStats-dense', () => describeDense(), CHECK_INDEXES_IO_POLICY);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           errors.push(`Dense index "${denseName}": ${msg}`);
@@ -302,7 +312,7 @@ export class PineconeIndexSession {
       } else {
         try {
           const describeSparse = sparseIndex.describeIndexStats;
-          await this.runIo('describeIndexStats-sparse', () => describeSparse());
+          await this.runIo('describeIndexStats-sparse', () => describeSparse(), CHECK_INDEXES_IO_POLICY);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           errors.push(`Sparse index "${sparseName}": ${msg}`);

--- a/src/core/pinecone/rerank.test.ts
+++ b/src/core/pinecone/rerank.test.ts
@@ -6,6 +6,10 @@ const sampleMerged: MergedHit[] = [
   { _id: '1', _score: 0.5, chunk_text: 'hello', metadata: { k: 'v' } },
 ];
 
+function makePc(rerank: ReturnType<typeof vi.fn>) {
+  return { inference: { rerank } } as unknown as Parameters<typeof rerankResults>[0];
+}
+
 describe('rerankResults', () => {
   it('returns empty outcome when there are no merged hits', async () => {
     const pc = {} as Parameters<typeof rerankResults>[0];
@@ -23,7 +27,7 @@ describe('rerankResults', () => {
         },
       ],
     });
-    const pc = { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+    const pc = makePc(rerank);
 
     const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
 
@@ -37,7 +41,7 @@ describe('rerankResults', () => {
 
   it('returns unreranked slice with degraded when rerank throws', async () => {
     const rerank = vi.fn().mockRejectedValue(new Error('rerank unavailable'));
-    const pc = { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+    const pc = makePc(rerank);
 
     const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
 
@@ -62,7 +66,7 @@ describe('rerankResults', () => {
         ],
       };
     });
-    const pc = { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+    const pc = makePc(rerank);
 
     const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
 
@@ -73,12 +77,72 @@ describe('rerankResults', () => {
 
   it('degrades after exhausting retries on persistent 503', async () => {
     const rerank = vi.fn().mockRejectedValue(new Error('HTTP 503'));
-    const pc = { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+    const pc = makePc(rerank);
 
     const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5, 5000);
 
     expect(out.degraded).toBe(true);
     expect(out.degradation_reason).toMatch(/^rerank_failed:/);
     expect(rerank).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns empty reranked results with degraded=false when data is an empty array', async () => {
+    const rerank = vi.fn().mockResolvedValue({ data: [] });
+    const pc = makePc(rerank);
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.results).toEqual([]);
+    expect(out.degraded).toBe(false);
+    expect(out.degradation_reason).toBeUndefined();
+  });
+
+  it('returns empty reranked results with degraded=false when data is absent', async () => {
+    const rerank = vi.fn().mockResolvedValue({});
+    const pc = makePc(rerank);
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.results).toEqual([]);
+    expect(out.degraded).toBe(false);
+  });
+
+  it('maps a rerank item with no document to an empty id/content result instead of throwing', async () => {
+    const rerank = vi.fn().mockResolvedValue({
+      data: [{ score: 0.42 }],
+    });
+    const pc = makePc(rerank);
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.degraded).toBe(false);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0]?.id).toBe('');
+    expect(out.results[0]?.content).toBe('');
+    expect(out.results[0]?.metadata).toEqual({});
+    expect(out.results[0]?.reranked).toBe(true);
+    expect(out.results[0]?.score).toBeCloseTo(0.42);
+  });
+
+  it('maps duplicate documents in the rerank output to one result per data item', async () => {
+    const document = { _id: '1', chunk_text: 'hello', metadata: { k: 'v' } };
+    const rerank = vi.fn().mockResolvedValue({
+      data: [
+        { score: 0.9, document },
+        { score: 0.8, document },
+      ],
+    });
+    const pc = makePc(rerank);
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.degraded).toBe(false);
+    expect(out.results).toHaveLength(2);
+    expect(out.results.map((r) => r.id)).toEqual(['1', '1']);
+    expect(out.results.map((r) => r.content)).toEqual(['hello', 'hello']);
+    expect(out.results[0]?.metadata).toEqual({ k: 'v' });
+    expect(out.results[0]?.score).toBeCloseTo(0.9);
+    expect(out.results[1]?.score).toBeCloseTo(0.8);
+    expect(out.results.every((r) => r.reranked === true)).toBe(true);
   });
 });

--- a/src/core/pinecone/rerank.test.ts
+++ b/src/core/pinecone/rerank.test.ts
@@ -47,4 +47,38 @@ describe('rerankResults', () => {
     expect(out.results[0]?.reranked).toBe(false);
     expect(out.results[0]?.content).toBe('hello');
   });
+
+  it('retries on 429 then succeeds without degrading', async () => {
+    let n = 0;
+    const rerank = vi.fn().mockImplementation(async () => {
+      n++;
+      if (n < 2) throw new Error('HTTP 429');
+      return {
+        data: [
+          {
+            score: 0.99,
+            document: { _id: '1', chunk_text: 'hello', metadata: { k: 'v' } },
+          },
+        ],
+      };
+    });
+    const pc = { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.degraded).toBe(false);
+    expect(out.results[0]?.reranked).toBe(true);
+    expect(rerank).toHaveBeenCalledTimes(2);
+  });
+
+  it('degrades after exhausting retries on persistent 503', async () => {
+    const rerank = vi.fn().mockRejectedValue(new Error('HTTP 503'));
+    const pc = { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5, 5000);
+
+    expect(out.degraded).toBe(true);
+    expect(out.degradation_reason).toMatch(/^rerank_failed:/);
+    expect(rerank).toHaveBeenCalledTimes(3);
+  });
 });

--- a/src/core/pinecone/rerank.ts
+++ b/src/core/pinecone/rerank.ts
@@ -4,6 +4,8 @@
 
 import type { Pinecone } from '@pinecone-database/pinecone';
 import { error as logError, redactApiKey } from '../../logger.js';
+import { DEFAULT_REQUEST_TIMEOUT_MS } from '../config.js';
+import { runWithPolicy } from '../server/retry.js';
 import type { MergedHit, SearchResult } from '../../types.js';
 
 export type RerankOutcome = {
@@ -22,28 +24,33 @@ export async function rerankResults(
   rerankModel: string,
   query: string,
   results: MergedHit[],
-  topN: number
+  topN: number,
+  requestTimeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS
 ): Promise<RerankOutcome> {
   if (!results || results.length === 0) {
     return { results: [], degraded: false };
   }
 
   try {
-    const rerankResult = await pc.inference.rerank({
-      model: rerankModel,
-      query,
-      // The Pinecone SDK types constrain document values to `Record<string, string>`,
-      // but the underlying HTTP API accepts any JSON value. We pass MergedHit objects
-      // (metadata may contain number/boolean/string[]) and only `chunk_text` — which is
-      // always a string — is accessed via rankFields. The double cast via `as unknown`
-      // is intentional: it bypasses the SDK's over-narrow type without stringifying
-      // metadata values that we need to read back from the returned documents.
-      documents: results as unknown as (string | Record<string, string>)[],
-      topN,
-      rankFields: ['chunk_text'],
-      returnDocuments: true,
-      parameters: { truncate: 'END' },
-    });
+    const rerankResult = await runWithPolicy(
+      async (_signal) =>
+        pc.inference.rerank({
+          model: rerankModel,
+          query,
+          // The Pinecone SDK types constrain document values to `Record<string, string>`,
+          // but the underlying HTTP API accepts any JSON value. We pass MergedHit objects
+          // (metadata may contain number/boolean/string[]) and only `chunk_text` — which is
+          // always a string — is accessed via rankFields. The double cast via `as unknown`
+          // is intentional: it bypasses the SDK's over-narrow type without stringifying
+          // metadata values that we need to read back from the returned documents.
+          documents: results as unknown as (string | Record<string, string>)[],
+          topN,
+          rankFields: ['chunk_text'],
+          returnDocuments: true,
+          parameters: { truncate: 'END' },
+        }),
+      { timeoutMs: requestTimeoutMs, label: 'rerank' }
+    );
 
     const reranked: SearchResult[] = [];
     for (const item of rerankResult.data || []) {

--- a/src/core/pinecone/search.test.ts
+++ b/src/core/pinecone/search.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   searchIndex,
   mergeResults,
@@ -7,6 +7,10 @@ import {
   countUniqueDocumentsFromHits,
 } from './search.js';
 import type { PineconeHit, SearchableIndex } from '../../types.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('searchIndex', () => {
   it('uses index.search when available and passes fields', async () => {
@@ -58,6 +62,36 @@ describe('searchIndex', () => {
     await expect(searchIndex(index, 'hi', 5, 'my-ns')).rejects.toThrow(
       'Pinecone search failed for namespace "my-ns": boom'
     );
+  });
+
+  it('retries on 503 then succeeds', async () => {
+    let n = 0;
+    const search = vi.fn().mockImplementation(async () => {
+      n++;
+      if (n < 2) throw new Error('HTTP 503');
+      return { result: { hits: [{ _id: '1', _score: 1, fields: {} }] } };
+    });
+    const index = { search } as unknown as SearchableIndex;
+    const hits = await searchIndex(index, 'hi', 5);
+    expect(hits).toHaveLength(1);
+    expect(search).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on 401', async () => {
+    const search = vi.fn().mockRejectedValue(new Error('HTTP 401'));
+    const index = { search } as unknown as SearchableIndex;
+    await expect(searchIndex(index, 'hi', 5)).rejects.toThrow(/401/);
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+
+  it('times out at requestTimeoutMs and preserves the timeout error prefix', async () => {
+    vi.useFakeTimers();
+    const search = vi.fn(() => new Promise(() => {}));
+    const index = { search } as unknown as SearchableIndex;
+    const p = searchIndex(index, 'hi', 5, undefined, undefined, undefined, 50);
+    const assertion = expect(p).rejects.toThrow(/^Timeout after 50ms while waiting for search/);
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
   });
 });
 

--- a/src/core/pinecone/search.ts
+++ b/src/core/pinecone/search.ts
@@ -4,6 +4,8 @@
 
 import { COUNT_FIELDS, COUNT_TOP_K } from '../../constants.js';
 import { debug as logDebug, warn as logWarn } from '../../logger.js';
+import { DEFAULT_REQUEST_TIMEOUT_MS } from '../config.js';
+import { isAppTimeoutError, runWithPolicy } from '../server/retry.js';
 import type {
   CountResult,
   MergedHit,
@@ -23,7 +25,8 @@ export async function searchIndex(
   topK: number,
   namespace?: string,
   metadataFilter?: Record<string, unknown>,
-  options?: { fields?: string[] }
+  options?: { fields?: string[] },
+  requestTimeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS
 ): Promise<PineconeHit[]> {
   // Build query payload in the same shape as Python implementation.
   const queryPayload: Record<string, unknown> = {
@@ -38,42 +41,50 @@ export async function searchIndex(
   }
 
   try {
-    // Preferred path: Pinecone search API.
-    if (typeof index.search === 'function') {
-      const searchOpts: {
-        namespace?: string;
-        query: Record<string, unknown>;
-        fields?: string[];
-      } = {
-        namespace,
-        query: queryPayload,
-      };
-      if (options?.fields?.length) {
-        searchOpts.fields = options.fields;
-      }
-      const result = await index.search(searchOpts);
-      return result?.result?.hits || [];
-    }
+    return await runWithPolicy(
+      async (_signal) => {
+        // Preferred path: Pinecone search API.
+        if (typeof index.search === 'function') {
+          const searchOpts: {
+            namespace?: string;
+            query: Record<string, unknown>;
+            fields?: string[];
+          } = {
+            namespace,
+            query: queryPayload,
+          };
+          if (options?.fields?.length) {
+            searchOpts.fields = options.fields;
+          }
+          const result = await index.search(searchOpts);
+          return result?.result?.hits || [];
+        }
 
-    // Backward-compatible fallback for older API shapes.
-    const target = namespace && index.namespace ? index.namespace(namespace) : index;
-    const queryParams: { query: Record<string, unknown>; fields?: string[] } = {
-      query: {
-        topK,
-        inputs: { text: query },
+        // Backward-compatible fallback for older API shapes.
+        const target = namespace && index.namespace ? index.namespace(namespace) : index;
+        const queryParams: { query: Record<string, unknown>; fields?: string[] } = {
+          query: {
+            topK,
+            inputs: { text: query },
+          },
+        };
+        if (metadataFilter !== undefined) {
+          queryParams.query['filter'] = metadataFilter;
+        }
+        if (options?.fields?.length) {
+          queryParams.fields = options.fields;
+        }
+        const result = target.searchRecords
+          ? await target.searchRecords(queryParams)
+          : { result: { hits: [] as PineconeHit[] } };
+        return result?.result?.hits || [];
       },
-    };
-    if (metadataFilter !== undefined) {
-      queryParams.query['filter'] = metadataFilter;
-    }
-    if (options?.fields?.length) {
-      queryParams.fields = options.fields;
-    }
-    const result = target.searchRecords
-      ? await target.searchRecords(queryParams)
-      : { result: { hits: [] as PineconeHit[] } };
-    return result?.result?.hits || [];
+      { timeoutMs: requestTimeoutMs, label: 'search' }
+    );
   } catch (error) {
+    if (isAppTimeoutError(error)) {
+      throw error;
+    }
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(
       `Pinecone search failed for namespace "${namespace ?? 'default'}": ${errorMessage}`

--- a/src/core/pinecone/searchable-index-conformance.test.ts
+++ b/src/core/pinecone/searchable-index-conformance.test.ts
@@ -40,4 +40,24 @@ describe('SearchableIndex SDK conformance (#220)', () => {
       expect(typeof namespaceHandle[method]).toBe('function');
     }
   );
+
+  // indexes.ts must call SDK methods on the index/namespace receiver inside runIo;
+  // detached calls throw against the real SDK (wpak-ai PR #225).
+  it('describeIndexStats throws when called detached from the index', () => {
+    const describeIndexStats = index.describeIndexStats as () => Promise<unknown>;
+    expect(() => describeIndexStats()).toThrow(
+      /_describeIndexStats|Cannot read properties of undefined/
+    );
+  });
+
+  it('namespace().query rejects when called detached from the namespace handle', async () => {
+    const query = namespaceHandle.query as (opts: {
+      topK: number;
+      vector: number[];
+      includeMetadata: boolean;
+    }) => Promise<unknown>;
+    await expect(query({ topK: 1, vector: [0], includeMetadata: true })).rejects.toThrow(
+      /_queryCommand|Cannot read properties of undefined/
+    );
+  });
 });

--- a/src/core/server/retry.test.ts
+++ b/src/core/server/retry.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { withRetry, withTimeout, defaultShouldRetry } from './retry.js';
+import {
+  withRetry,
+  withTimeout,
+  defaultShouldRetry,
+  transientShouldRetry,
+  isAppTimeoutError,
+  runWithPolicy,
+} from './retry.js';
 
 afterEach(() => {
   vi.useRealTimers();
@@ -11,6 +18,74 @@ describe('defaultShouldRetry', () => {
   });
   it('does not retry on 400', () => {
     expect(defaultShouldRetry(new Error('HTTP 400'))).toBe(false);
+  });
+});
+
+describe('transientShouldRetry', () => {
+  it('retries on 503 in message', () => {
+    expect(transientShouldRetry(new Error('HTTP 503'))).toBe(true);
+  });
+
+  it('does not retry on 401', () => {
+    expect(transientShouldRetry(new Error('HTTP 401'))).toBe(false);
+  });
+
+  it('does not retry app-level withTimeout deadlines', () => {
+    expect(transientShouldRetry(new Error('Timeout after 50ms while waiting for search'))).toBe(
+      false
+    );
+  });
+});
+
+describe('isAppTimeoutError', () => {
+  it('matches withTimeout rejection messages', () => {
+    expect(isAppTimeoutError(new Error('Timeout after 50ms while waiting for search'))).toBe(true);
+  });
+});
+
+describe('runWithPolicy', () => {
+  it('retries then succeeds on transient 503', async () => {
+    let n = 0;
+    const v = await runWithPolicy(
+      async () => {
+        n++;
+        if (n < 2) throw new Error('HTTP 503');
+        return 'done';
+      },
+      { timeoutMs: 1000, label: 'test', retries: 2, backoffMs: 1 }
+    );
+    expect(v).toBe('done');
+    expect(n).toBe(2);
+  });
+
+  it('fails fast on non-retryable 401', async () => {
+    let n = 0;
+    await expect(
+      runWithPolicy(
+        async () => {
+          n++;
+          throw new Error('HTTP 401');
+        },
+        { timeoutMs: 1000, label: 'test', retries: 2, backoffMs: 1 }
+      )
+    ).rejects.toThrow('HTTP 401');
+    expect(n).toBe(1);
+  });
+
+  it('does not retry when the per-attempt timeout fires', async () => {
+    vi.useFakeTimers();
+    let n = 0;
+    const p = runWithPolicy(
+      async () => {
+        n++;
+        return new Promise<string>(() => {});
+      },
+      { timeoutMs: 50, label: 'test', retries: 2, backoffMs: 1 }
+    );
+    const assertion = expect(p).rejects.toThrow(/Timeout after 50ms/);
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+    expect(n).toBe(1);
   });
 });
 

--- a/src/core/server/retry.ts
+++ b/src/core/server/retry.ts
@@ -7,6 +7,16 @@
  * waiter still rejects immediately on timeout.
  */
 
+import { warn, redactApiKey } from '../../logger.js';
+
+/** Matches {@link withTimeout} rejection message prefix; used by tool-error and callers. */
+export const APP_TIMEOUT_PATTERN = /^Timeout after \d+ms while waiting for /i;
+
+export function isAppTimeoutError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return APP_TIMEOUT_PATTERN.test(msg);
+}
+
 /** Retry policy. */
 export interface RetryOptions {
   /** Total number of attempts after the first try. Default 2. */
@@ -27,6 +37,14 @@ export interface TimeoutOptions {
   label?: string;
 }
 
+/** Per-call timeout + transient retry policy for outbound Pinecone I/O. */
+export interface PolicyOptions {
+  timeoutMs: number;
+  label: string;
+  retries?: number;
+  backoffMs?: number;
+}
+
 /** Default predicate: retry on common transient HTTP statuses (429/5xx) and network-ish messages. */
 export function defaultShouldRetry(error: unknown): boolean {
   if (error instanceof Error) {
@@ -41,6 +59,12 @@ export function defaultShouldRetry(error: unknown): boolean {
     return true;
   }
   return false;
+}
+
+/** Retry 429/5xx + network errors; do NOT retry app-level {@link withTimeout} deadlines. */
+export function transientShouldRetry(error: unknown): boolean {
+  if (isAppTimeoutError(error)) return false;
+  return defaultShouldRetry(error);
 }
 
 /**
@@ -101,4 +125,23 @@ export async function withTimeout<T>(
     // When the deadline wins, `fnPromise` may still reject from abort listeners.
     void fnPromise.catch(() => {});
   }
+}
+
+/**
+ * Compose per-attempt timeout with bounded transient retry for Pinecone I/O.
+ * Each retry gets a fresh timeout window.
+ */
+export function runWithPolicy<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  options: PolicyOptions
+): Promise<T> {
+  return withRetry(() => withTimeout(fn, { timeoutMs: options.timeoutMs, label: options.label }), {
+    retries: options.retries,
+    backoffMs: options.backoffMs,
+    shouldRetry: transientShouldRetry,
+    onRetry: (attempt, error) => {
+      const msg = redactApiKey(error instanceof Error ? error.message : String(error));
+      warn(`Retrying ${options.label} (attempt ${attempt})`, msg);
+    },
+  });
 }

--- a/src/core/server/tool-error.ts
+++ b/src/core/server/tool-error.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod';
 import { getLogLevel, error as logError, info } from '../../logger.js';
+import { isAppTimeoutError } from './retry.js';
 
 /** User-facing error message: detailed in DEBUG, generic otherwise. */
 export function getToolErrorMessage(error: unknown, fallbackMessage: string): string {
@@ -81,9 +82,6 @@ export type ToolError = z.infer<typeof toolErrorSchema>;
 
 const DEFAULT_TIMEOUT_SUGGESTION = 'Retry the request, or increase --request-timeout-ms.';
 
-/** Matches {@link withTimeout} rejection message prefix in `retry.ts`. */
-const TIMEOUT_MESSAGE_PATTERN = /^Timeout after \d+ms while waiting for /i;
-
 export function flowGateToolError(namespace: string, message: string): ToolError {
   return {
     code: 'FLOW_GATE',
@@ -136,18 +134,12 @@ export function lifecycleToolError(message: string): ToolError {
   };
 }
 
-function rawErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 /**
  * Map an unexpected thrown error to {@link ToolError} for MCP responses.
- * Uses raw `Error#message` for timeout detection (DEBUG mode replaces the user message).
  */
 export function classifyToolCatchError(error: unknown, fallbackMessage: string): ToolError {
-  const raw = rawErrorMessage(error);
   const message = getToolErrorMessage(error, fallbackMessage);
-  if (TIMEOUT_MESSAGE_PATTERN.test(raw)) {
+  if (isAppTimeoutError(error)) {
     return timeoutToolError(message);
   }
   return pineconeToolError(message);


### PR DESCRIPTION
### Summary

- Add `runWithPolicy` (`withRetry` + `withTimeout`) with `transientShouldRetry` so app-level timeouts fail fast while 429/502/503/504 and network errors get bounded backoff
- Apply the policy to search, rerank, `describeIndexStats`, namespace metadata sampling, and `fetchRecordFields`
- Thread `requestTimeoutMs` from `PineconeClient` through `PineconeIndexSession.getRequestTimeoutMs()` into all outbound call sites
- Deduplicate timeout detection via `isAppTimeoutError` (shared by `search.ts` and `tool-error.ts`)

### Test plan

- [x] `npm run ci` green (415 tests, 85%+ coverage)
- [x] Retry/timeout/non-retry tests in `retry.test.ts`, `search.test.ts`, `rerank.test.ts`, `indexes.test.ts`, `pinecone-client.test.ts`

### Follow-up (not in scope)

Hybrid per-leg search timeouts are logged but still surface as a generic error when both legs fail; `TIMEOUT` tool-error classification for partial hybrid degradation is unchanged.

### Related Issue

- Close https://github.com/cppalliance/pinecone-read-only-mcp-typescript/issues/207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Added consistent, configurable request timeouts across Pinecone search (including hybrid), index reachability checks, namespace metadata sampling, record field fetching, and reranking.
  * Improved retry behavior: retry only transient failures, fail fast for non-retryable errors, and immediately surface app-level timeout errors (including when hybrid legs fail).
  * Hybrid search now propagates timeout errors more precisely instead of falling back to a generic failure.
* **Tooling/Errors**
  * Improved timeout classification and standardized tool error message logging for clearer diagnostics.
* **Testing**
  * Expanded coverage for timeout propagation, retry/degradation behavior, and SDK conformance edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->