### PR TITLE
Add reranker result-mapping edge-case tests (#224)

### DIFF
--- a/src/core/pinecone/rerank.test.ts
+++ b/src/core/pinecone/rerank.test.ts
@@ -6,6 +6,10 @@ const sampleMerged: MergedHit[] = [
   { _id: '1', _score: 0.5, chunk_text: 'hello', metadata: { k: 'v' } },
 ];
 
+function makePc(rerank: ReturnType<typeof vi.fn>) {
+  return { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+}
+
 describe('rerankResults', () => {
   it('returns empty outcome when there are no merged hits', async () => {
     const pc = {} as Parameters<typeof rerankResults>[0];
@@ -23,7 +27,7 @@ describe('rerankResults', () => {
         },
       ],
     });
-    const pc = { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+    const pc = makePc(rerank);
 
     const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
 
@@ -37,7 +41,7 @@ describe('rerankResults', () => {
 
   it('returns unreranked slice with degraded when rerank throws', async () => {
     const rerank = vi.fn().mockRejectedValue(new Error('rerank unavailable'));
-    const pc = { inference: { rerank } } as Parameters<typeof rerankResults>[0];
+    const pc = makePc(rerank);
 
     const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
 
@@ -46,5 +50,65 @@ describe('rerankResults', () => {
     expect(out.degradation_reason).toMatch(/^rerank_failed:/);
     expect(out.results[0]?.reranked).toBe(false);
     expect(out.results[0]?.content).toBe('hello');
+  });
+
+  it('returns empty reranked results with degraded=false when data is an empty array', async () => {
+    const rerank = vi.fn().mockResolvedValue({ data: [] });
+    const pc = makePc(rerank);
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.results).toEqual([]);
+    expect(out.degraded).toBe(false);
+    expect(out.degradation_reason).toBeUndefined();
+  });
+
+  it('returns empty reranked results with degraded=false when data is absent', async () => {
+    const rerank = vi.fn().mockResolvedValue({});
+    const pc = makePc(rerank);
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.results).toEqual([]);
+    expect(out.degraded).toBe(false);
+  });
+
+  it('maps a rerank item with no document to an empty id/content result instead of throwing', async () => {
+    const rerank = vi.fn().mockResolvedValue({
+      data: [{ score: 0.42 }],
+    });
+    const pc = makePc(rerank);
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.degraded).toBe(false);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0]?.id).toBe('');
+    expect(out.results[0]?.content).toBe('');
+    expect(out.results[0]?.metadata).toEqual({});
+    expect(out.results[0]?.reranked).toBe(true);
+    expect(out.results[0]?.score).toBeCloseTo(0.42);
+  });
+
+  it('maps duplicate documents in the rerank output to one result per data item', async () => {
+    const document = { _id: '1', chunk_text: 'hello', metadata: { k: 'v' } };
+    const rerank = vi.fn().mockResolvedValue({
+      data: [
+        { score: 0.9, document },
+        { score: 0.8, document },
+      ],
+    });
+    const pc = makePc(rerank);
+
+    const out = await rerankResults(pc, 'm', 'q', sampleMerged, 5);
+
+    expect(out.degraded).toBe(false);
+    expect(out.results).toHaveLength(2);
+    expect(out.results.map((r) => r.id)).toEqual(['1', '1']);
+    expect(out.results.map((r) => r.content)).toEqual(['hello', 'hello']);
+    expect(out.results[0]?.metadata).toEqual({ k: 'v' });
+    expect(out.results[0]?.score).toBeCloseTo(0.9);
+    expect(out.results[1]?.score).toBeCloseTo(0.8);
+    expect(out.results.every((r) => r.reranked === true)).toBe(true);
   });
 });


### PR DESCRIPTION
Adds the missing edge-case tests for `rerankResults` result mapping (`src/core/pinecone/rerank.ts`). The suite previously covered only the happy path, empty input, and the rerank-throws fallback.

New tests:

- Empty `data` array with a non-empty input returns empty reranked results with `degraded: false` and no `degradation_reason`.
- Absent `data` (response is `{}`) returns empty reranked results with `degraded: false`.
- A rerank item with no `document` maps to a result with empty `id`/`content`/`metadata` and `reranked: true` instead of throwing.
- Duplicate documents in the output map to one `SearchResult` per data item, with the fields preserved on each.

Each test asserts the mapped `SearchResult` fields (id, content, score, metadata, reranked). Also extracted a small `makePc` helper so the repeated `pc` cast lives in one place.

This covers the live document-mapping path (`returnDocuments: true`). The index-based remap cases (out-of-range index) are tracked in #227, gated on rerank moving to `returnDocuments: false`, since there is no index-remap code to exercise today.

Test-only change. rerank tests 7/7 pass, `format:check` and typecheck clean.

Closes #224.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for reranking when responses are empty or missing expected data.
  * Added validation for items without documents, including safe default values.
  * Added coverage for duplicate documents and consistent result mapping.
  * Simplified test setup for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
